### PR TITLE
added BrDisplayUser test

### DIFF
--- a/cypress/component/BrDisplayUser.cy.tsx
+++ b/cypress/component/BrDisplayUser.cy.tsx
@@ -2,23 +2,19 @@ import React = require("react");
 import BrDisplayUser from "../../components/brickroom/BrDisplayUser";
 import "../../styles/globals.scss";
 
-describe("AddContributors.cy.tsx", () => {
-    it("something", () => {
-        /**
-         * Setup
-         */
-
+describe("BrDisplayUser component", () => {
+    it("should mount and check that all the info are visible", () => {
         // Mounting component
         const name = "Mino";
         const location = "Bari";
         cy.mount(<BrDisplayUser id="1" name={name} location={location} />);
 
         // Visibility check
+        cy.get("a").should("be.visible");
         cy.contains(name).should("be.visible");
         cy.contains(location).should("be.visible");
         cy.get("svg").should("be.visible");
-
-        // Click on link does not work because <link> works inside the app
-        // Not in component testing
     });
+
+    // Functionality is tested here:
 });

--- a/cypress/component/BrDisplayUser.cy.tsx
+++ b/cypress/component/BrDisplayUser.cy.tsx
@@ -1,0 +1,24 @@
+import React = require("react");
+import BrDisplayUser from "../../components/brickroom/BrDisplayUser";
+import "../../styles/globals.scss";
+
+describe("AddContributors.cy.tsx", () => {
+    it("something", () => {
+        /**
+         * Setup
+         */
+
+        // Mounting component
+        const name = "Mino";
+        const location = "Bari";
+        cy.mount(<BrDisplayUser id="1" name={name} location={location} />);
+
+        // Visibility check
+        cy.contains(name).should("be.visible");
+        cy.contains(location).should("be.visible");
+        cy.get("svg").should("be.visible");
+
+        // Click on link does not work because <link> works inside the app
+        // Not in component testing
+    });
+});

--- a/cypress/e2e/components/BrDisplayUser.cy.tsx
+++ b/cypress/e2e/components/BrDisplayUser.cy.tsx
@@ -1,0 +1,14 @@
+describe("BrDisplayUser component", () => {
+    it("should click the component and check if navigation works", () => {
+        cy.visit("/");
+        // // Mounting component
+        // const name = "Mino";
+        // const location = "Bari";
+        // cy.mount(<BrDisplayUser id="1" name={name} location={location} />);
+
+        // // Visibility check
+        // cy.contains(name).should("be.visible");
+        // cy.contains(location).should("be.visible");
+        // cy.get("svg").should("be.visible");
+    });
+});

--- a/cypress/e2e/components/BrDisplayUser.cy.tsx
+++ b/cypress/e2e/components/BrDisplayUser.cy.tsx
@@ -10,13 +10,19 @@ describe("BrDisplayUser component", () => {
     });
 
     it("should click the component and go to user page", () => {
-        // Getting the first instance
-        const comp = cy.get("tr > td > a").first().should("be.visible");
-        // // Getting the text inside the istance (the username)
-        // let text = "";
-        // comp.then(function ($elem) {
-        //     text = $elem.text();
-        // });
-        // cy.log(text);
+        // Waiting for data
+        const name = "dataGetFirst";
+        cy.intercept("http://65.109.11.42:9000/api").as(name);
+        cy.wait(`@${name}`);
+
+        // Getting the first instance of the component
+        const comp = cy.get("tr > td > a").first();
+        // Checking if it's visible
+        comp.should("be.visible");
+        // Clicking to navigate
+        comp.click().then((a) => {
+            // Checking if url is correct
+            cy.location("href").should("eq", a.prop("href"));
+        });
     });
 });

--- a/cypress/e2e/components/BrDisplayUser.cy.tsx
+++ b/cypress/e2e/components/BrDisplayUser.cy.tsx
@@ -1,14 +1,22 @@
 describe("BrDisplayUser component", () => {
-    it("should click the component and check if navigation works", () => {
-        cy.visit("/");
-        // // Mounting component
-        // const name = "Mino";
-        // const location = "Bari";
-        // cy.mount(<BrDisplayUser id="1" name={name} location={location} />);
+    before(() => {
+        cy.login();
+        cy.saveLocalStorage();
+    });
 
-        // // Visibility check
-        // cy.contains(name).should("be.visible");
-        // cy.contains(location).should("be.visible");
-        // cy.get("svg").should("be.visible");
+    beforeEach(() => {
+        cy.visit("/assets");
+        cy.restoreLocalStorage();
+    });
+
+    it("should click the component and go to user page", () => {
+        // Getting the first instance
+        const comp = cy.get("tr > td > a").first().should("be.visible");
+        // // Getting the text inside the istance (the username)
+        // let text = "";
+        // comp.then(function ($elem) {
+        //     text = $elem.text();
+        // });
+        // cy.log(text);
     });
 });


### PR DESCRIPTION
This should close #84 

Problems in the component
- Hover state is missing
- `href='profile/{id}'` is too hardcoded. In other contexts the profile href can have another structure
  - `id` prop should be changed in `href` for full reusability
- Clicking the component during component testing generates an error: `(uncaught exception)TypeError: Cannot use 'in' operator to search for 'softPush' in null`.
  - Removing `<link>` from component solves the error. I think next's `<link>` component doesn't work in Cypress' **component testing**