### PR TITLE
feat(dpp): ✨ dedicated DPP detail page with prototype-matching UI

### DIFF
--- a/.beads/last-touched
+++ b/.beads/last-touched
@@ -1,1 +1,1 @@
-interfacer-gui-7yb.6
+interfacer-gui-7yb.10.4

--- a/.beads/last-touched
+++ b/.beads/last-touched
@@ -1,1 +1,1 @@
-interfacer-gui-ve1.1
+interfacer-gui-7yb.6

--- a/components/ProfilePageNew.tsx
+++ b/components/ProfilePageNew.tsx
@@ -335,6 +335,7 @@ function ProfileTabContent({
 
 function DppsTabContent({ userId, isOwner, ctaConfig }: { userId: string; isOwner: boolean; ctaConfig: TabCtaConfig }) {
   const { t } = useTranslation("common");
+  const router = useRouter();
   const dppApi = useDppApi();
   const [dpps, setDpps] = useState<DppDocument[]>([]);
   const [total, setTotal] = useState(0);
@@ -551,7 +552,7 @@ function DppsTabContent({ userId, isOwner, ctaConfig }: { userId: string; isOwne
           <div
             className="grid gap-4 px-5 py-3 border-b border-ifr text-ifr-text-secondary"
             style={{
-              gridTemplateColumns: "2fr 1fr 100px 100px 140px",
+              gridTemplateColumns: "2fr 1fr 100px 100px 140px 90px",
               fontFamily: "var(--ifr-font-body)",
               fontSize: "var(--ifr-fs-sm)",
               fontWeight: "var(--ifr-fw-semibold)",
@@ -562,6 +563,7 @@ function DppsTabContent({ userId, isOwner, ctaConfig }: { userId: string; isOwne
             <span>{t("Type")}</span>
             <span>{t("Status")}</span>
             <span>{t("Created")}</span>
+            <span>{t("Action")}</span>
           </div>
 
           {/* Table rows */}
@@ -570,20 +572,35 @@ function DppsTabContent({ userId, isOwner, ctaConfig }: { userId: string; isOwne
               dpp.productOverview?.productName?.value || dpp.productOverview?.brandName?.value || t("Untitled DPP");
             const status = dpp.status || "draft";
             const colors = statusColors[status] || statusColors.draft;
+            const dppUrl = `/dpps/${encodeURIComponent(dpp.id)}`;
 
             return (
               <div
                 key={dpp.id}
                 className="grid gap-4 px-5 py-4 border-b border-ifr last:border-b-0 hover:bg-ifr-hover/50 transition-colors items-center"
+                role="link"
+                tabIndex={0}
+                onClick={() => router.push(dppUrl)}
+                onKeyDown={event => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    router.push(dppUrl);
+                  }
+                }}
                 style={{
-                  gridTemplateColumns: "2fr 1fr 100px 100px 140px",
+                  gridTemplateColumns: "2fr 1fr 100px 100px 140px 90px",
                   fontFamily: "var(--ifr-font-body)",
                   fontSize: "var(--ifr-fs-base)",
                 }}
               >
-                <span className="text-ifr-text-primary truncate" style={{ fontWeight: "var(--ifr-fw-medium)" }}>
-                  {productName}
-                </span>
+                <Link href={dppUrl}>
+                  <a
+                    className="text-ifr-text-primary truncate no-underline hover:underline"
+                    style={{ fontWeight: "var(--ifr-fw-medium)" }}
+                  >
+                    {productName}
+                  </a>
+                </Link>
                 <span className="text-ifr-text-secondary truncate">{dpp.batchId || "—"}</span>
                 <span>
                   <span
@@ -614,6 +631,19 @@ function DppsTabContent({ userId, isOwner, ctaConfig }: { userId: string; isOwne
                 <span className="text-ifr-text-secondary" style={{ fontSize: "var(--ifr-fs-sm)" }}>
                   {dpp.createdAt ? new Date(dpp.createdAt).toLocaleDateString() : "—"}
                 </span>
+                <Link href={dppUrl}>
+                  <a
+                    className="inline-flex items-center justify-center px-2 py-1 border border-ifr no-underline hover:bg-ifr-hover/70"
+                    style={{
+                      borderRadius: "var(--ifr-radius-sm)",
+                      color: "var(--ifr-text-primary)",
+                      fontSize: "var(--ifr-fs-sm)",
+                      fontWeight: "var(--ifr-fw-medium)",
+                    }}
+                  >
+                    {t("View")}
+                  </a>
+                </Link>
               </div>
             );
           })}

--- a/components/ProjectDetailNew.tsx
+++ b/components/ProjectDetailNew.tsx
@@ -909,7 +909,6 @@ function DppDisplay({ dpp }: { dpp: Record<string, string> }) {
 /** Card for a single DPP in the Digital Product Passports list. */
 function DppListCard({ dpp, index, color }: { dpp: DppDocument; index: number; color: string }) {
   const { t } = useTranslation("common");
-  const [expanded, setExpanded] = useState(false);
 
   const label = dpp.productOverview?.productName?.value || `DPP-${String(index + 1).padStart(3, "0")}`;
   const batchLabel = dpp.batchType === "unit" ? t("Unit") : t("Batch");
@@ -979,28 +978,21 @@ function DppListCard({ dpp, index, color }: { dpp: DppDocument; index: number; c
         </div>
 
         {/* View DPP button */}
-        <button
-          type="button"
-          onClick={() => setExpanded(v => !v)}
-          className="shrink-0 px-3 py-1.5 bg-transparent border border-ifr hover:bg-ifr-hover transition-colors cursor-pointer"
-          style={{
-            borderRadius: "var(--ifr-radius-sm)",
-            fontFamily: "var(--ifr-font-body)",
-            fontSize: "var(--ifr-fs-xs)",
-            fontWeight: "var(--ifr-fw-medium)",
-            color: "var(--ifr-text-primary)",
-          }}
-        >
-          {expanded ? t("Hide DPP") : t("View DPP")}
-        </button>
+        <Link href={`/dpps/${encodeURIComponent(dpp.id)}`}>
+          <a
+            className="shrink-0 px-3 py-1.5 bg-transparent border border-ifr hover:bg-ifr-hover transition-colors cursor-pointer no-underline"
+            style={{
+              borderRadius: "var(--ifr-radius-sm)",
+              fontFamily: "var(--ifr-font-body)",
+              fontSize: "var(--ifr-fs-xs)",
+              fontWeight: "var(--ifr-fw-medium)",
+              color: "var(--ifr-text-primary)",
+            }}
+          >
+            {t("View DPP")}
+          </a>
+        </Link>
       </div>
-
-      {/* Expanded detail */}
-      {expanded && (
-        <div className="border-t border-ifr p-4 bg-white">
-          <DppDocumentDetail dpp={dpp} />
-        </div>
-      )}
     </div>
   );
 }

--- a/lib/dpp-pdf.ts
+++ b/lib/dpp-pdf.ts
@@ -1,0 +1,284 @@
+import { jsPDF } from "jspdf";
+import autoTable from "jspdf-autotable";
+import type { DppDocument } from "./dpp-types";
+
+// --- Helpers (mirrored from the page) ---
+
+function prettifyKey(key: string): string {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/_/g, " ")
+    .replace(/^./, first => first.toUpperCase());
+}
+
+function getFieldValue(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return String(value);
+  if (Array.isArray(value)) {
+    if (value.length === 0) return null;
+    return value.map(getFieldValue).filter(Boolean).join(", ") || null;
+  }
+  if (typeof value === "object") {
+    const tv = value as { value?: unknown; units?: unknown };
+    if (Object.prototype.hasOwnProperty.call(tv, "value")) {
+      const scalar = getFieldValue(tv.value);
+      if (!scalar) return null;
+      const units = typeof tv.units === "string" ? tv.units : null;
+      return units ? `${scalar} ${units}` : scalar;
+    }
+  }
+  return null;
+}
+
+function sectionFields(section: unknown): Array<{ label: string; value: string }> {
+  if (!section || typeof section !== "object" || Array.isArray(section)) return [];
+  return Object.entries(section)
+    .map(([key, raw]) => {
+      const value = getFieldValue(raw);
+      if (!value) return null;
+      return { label: prettifyKey(key), value };
+    })
+    .filter((f): f is { label: string; value: string } => f !== null);
+}
+
+// --- Section configuration (same order & colors as UI) ---
+
+const sectionConfig: Array<{ key: keyof DppDocument; title: string; subtitle: string; color: string }> = [
+  {
+    key: "productOverview",
+    title: "DPP Overview",
+    subtitle: "Basic product information and identification",
+    color: "#E87C1E",
+  },
+  {
+    key: "complianceAndStandards",
+    title: "Compliance & Standards",
+    subtitle: "Regulatory compliance information",
+    color: "#2E7D32",
+  },
+  {
+    key: "reparability",
+    title: "Reparability",
+    subtitle: "Repair instructions and spare parts availability",
+    color: "#1565C0",
+  },
+  {
+    key: "environmentalImpact",
+    title: "Environmental Impact",
+    subtitle: "Resource consumption and emissions data",
+    color: "#558B2F",
+  },
+  {
+    key: "certificates",
+    title: "Certificates",
+    subtitle: "Environmental and quality certifications",
+    color: "#6A1B9A",
+  },
+  {
+    key: "recyclability",
+    title: "Recyclability",
+    subtitle: "Material composition and recycling information",
+    color: "#00838F",
+  },
+  {
+    key: "energyUseAndEfficiency",
+    title: "Energy Use & Efficiency",
+    subtitle: "Battery and power specifications",
+    color: "#EF6C00",
+  },
+  {
+    key: "economicOperator",
+    title: "Economic Operator",
+    subtitle: "Manufacturer and company information",
+    color: "#4E342E",
+  },
+  {
+    key: "repairInformation",
+    title: "Information about the Repair",
+    subtitle: "Repair events and documentation",
+    color: "#1565C0",
+  },
+  {
+    key: "refurbishmentInformation",
+    title: "Information about the Refurbishment",
+    subtitle: "Refurbishment events and processes",
+    color: "#00695C",
+  },
+  {
+    key: "recyclingInformation",
+    title: "Information on the Recycling",
+    subtitle: "End-of-life recycling data",
+    color: "#37474F",
+  },
+  {
+    key: "consumerInformation",
+    title: "Consumer Information",
+    subtitle: "Product usage and safety details",
+    color: "#AD1457",
+  },
+  {
+    key: "dosageInstructions",
+    title: "Dosage Instructions",
+    subtitle: "Application and dosage guidance",
+    color: "#C62828",
+  },
+  { key: "ingredients", title: "Ingredients", subtitle: "Ingredient and substance listing", color: "#283593" },
+  { key: "packaging", title: "Packaging", subtitle: "Packaging materials and specifications", color: "#795548" },
+];
+
+// --- Color helpers ---
+
+function hexToRgb(hex: string): [number, number, number] {
+  const n = parseInt(hex.replace("#", ""), 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+function rgbAlpha(hex: string, alpha: number): [number, number, number] {
+  const [r, g, b] = hexToRgb(hex);
+  return [
+    Math.round(r * alpha + 255 * (1 - alpha)),
+    Math.round(g * alpha + 255 * (1 - alpha)),
+    Math.round(b * alpha + 255 * (1 - alpha)),
+  ];
+}
+
+// --- PDF generation ---
+
+const BRAND = "#E87C1E";
+const PAGE_LEFT = 20;
+const PAGE_RIGHT = 190;
+const CONTENT_WIDTH = PAGE_RIGHT - PAGE_LEFT;
+
+export function generateDppPdf(dpp: DppDocument): void {
+  const doc = new jsPDF({ orientation: "portrait", unit: "mm", format: "a4" });
+
+  const productName = dpp.productOverview?.productName?.value || dpp.batchId || dpp.id;
+  const status = (dpp.status || "draft").charAt(0).toUpperCase() + (dpp.status || "draft").slice(1);
+  const createdAt = dpp.createdAt ? new Date(dpp.createdAt).toLocaleDateString() : "-";
+
+  let y = 20;
+
+  // ── Header band ──
+  doc.setFillColor(...hexToRgb(BRAND));
+  doc.rect(0, 0, 210, 38, "F");
+
+  doc.setTextColor(255, 255, 255);
+  doc.setFontSize(10);
+  doc.setFont("helvetica", "normal");
+  doc.text("Digital Product Passport", PAGE_LEFT, 14);
+
+  doc.setFontSize(20);
+  doc.setFont("helvetica", "bold");
+  doc.text(String(productName), PAGE_LEFT, 26);
+
+  doc.setFontSize(9);
+  doc.setFont("helvetica", "normal");
+  const statusText = `Status: ${status}`;
+  const dateText = `Published: ${createdAt}`;
+  const idText = `ID: ${dpp.id}`;
+  doc.text([statusText, dateText, idText].join("   •   "), PAGE_LEFT, 34);
+
+  y = 46;
+
+  // Batch row
+  if (dpp.batchId) {
+    doc.setTextColor(100, 100, 100);
+    doc.setFontSize(9);
+    doc.text(`Batch: ${dpp.batchId}`, PAGE_LEFT, y);
+    y += 6;
+  }
+
+  // Product link
+  if (dpp.productId) {
+    doc.setTextColor(100, 100, 100);
+    doc.setFontSize(9);
+    doc.text(`Product: ${dpp.productId}`, PAGE_LEFT, y);
+    y += 6;
+  }
+
+  y += 4;
+
+  // ── Sections ──
+  const populatedSections = sectionConfig
+    .map(cfg => {
+      const fields = sectionFields(dpp[cfg.key]);
+      if (fields.length === 0) return null;
+      return { ...cfg, fields };
+    })
+    .filter(Boolean) as Array<(typeof sectionConfig)[number] & { fields: Array<{ label: string; value: string }> }>;
+
+  for (const section of populatedSections) {
+    // Check if we have room for at least the section header + a few rows
+    if (y > 255) {
+      doc.addPage();
+      y = 20;
+    }
+
+    // Section header bar
+    const [bgR, bgG, bgB] = rgbAlpha(section.color, 0.1);
+    doc.setFillColor(bgR, bgG, bgB);
+    doc.roundedRect(PAGE_LEFT, y, CONTENT_WIDTH, 12, 2, 2, "F");
+
+    // Colored dot
+    doc.setFillColor(...hexToRgb(section.color));
+    doc.circle(PAGE_LEFT + 6, y + 6, 2.5, "F");
+
+    // Section title
+    doc.setTextColor(...hexToRgb(section.color));
+    doc.setFontSize(11);
+    doc.setFont("helvetica", "bold");
+    doc.text(section.title, PAGE_LEFT + 12, y + 5.5);
+
+    // Section subtitle
+    doc.setTextColor(120, 120, 120);
+    doc.setFontSize(7.5);
+    doc.setFont("helvetica", "normal");
+    doc.text(section.subtitle, PAGE_LEFT + 12, y + 10);
+
+    y += 16;
+
+    // Field table
+    autoTable(doc, {
+      startY: y,
+      margin: { left: PAGE_LEFT, right: 210 - PAGE_RIGHT },
+      head: [["Field", "Value"]],
+      body: section.fields.map(f => [f.label, f.value]),
+      theme: "grid",
+      styles: {
+        fontSize: 8.5,
+        cellPadding: 3,
+        lineColor: [220, 220, 220],
+        lineWidth: 0.3,
+        textColor: [50, 50, 50],
+      },
+      headStyles: {
+        fillColor: hexToRgb(section.color),
+        textColor: [255, 255, 255],
+        fontStyle: "bold",
+        fontSize: 8.5,
+      },
+      alternateRowStyles: {
+        fillColor: [248, 248, 248],
+      },
+      columnStyles: {
+        0: { cellWidth: 60, fontStyle: "bold", textColor: [80, 80, 80] },
+      },
+    });
+
+    // Advance y past the table
+    y = (doc as any).lastAutoTable.finalY + 10;
+  }
+
+  // ── Footer on every page ──
+  const pageCount = doc.getNumberOfPages();
+  for (let i = 1; i <= pageCount; i++) {
+    doc.setPage(i);
+    doc.setFontSize(7);
+    doc.setTextColor(160, 160, 160);
+    doc.text(`Digital Product Passport — ${String(productName)}`, PAGE_LEFT, 290);
+    doc.text(`Page ${i} of ${pageCount}`, PAGE_RIGHT, 290, { align: "right" });
+  }
+
+  // Trigger download
+  doc.save(`DPP-${dpp.id}.pdf`);
+}

--- a/lib/dpp.ts
+++ b/lib/dpp.ts
@@ -10,7 +10,7 @@
 
 // @ts-ignore
 import { useAuth } from "hooks/useAuth";
-import useStorage from "hooks/useStorage";
+import { useCallback, useMemo } from "react";
 // @ts-ignore
 import sign from "zenflows-crypto/src/sign_graphql.zen";
 import type {
@@ -42,186 +42,238 @@ class DppRequestError extends Error {
 export { DppRequestError };
 
 const useDppApi = () => {
-  const { getItem } = useStorage();
   const { user } = useAuth();
 
-  async function signBody(body: string): Promise<{ "did-sign": string; "did-pk": string }> {
-    const zencode_exec = (await import("zenroom")).zencode_exec;
-    const data = `{"gql": "${Buffer.from(body, "utf8").toString("base64")}"}`;
-    const keys = `{"keyring": {"eddsa": "${getItem("eddsaPrivateKey")}"}}`;
-    const { result } = await zencode_exec(sign, { data, keys });
-    return {
-      "did-sign": JSON.parse(result).eddsa_signature,
-      "did-pk": String(user?.publicKey),
-    };
-  }
+  const signBody = useCallback(
+    async (body: string): Promise<{ "did-sign": string; "did-pk": string }> => {
+      const zencode_exec = (await import("zenroom")).zencode_exec;
+      const eddsaKey = typeof window !== "undefined" ? window.localStorage.getItem("eddsaPrivateKey") || "" : "";
+      const data = `{"gql": "${Buffer.from(body, "utf8").toString("base64")}"}`;
+      const keys = `{"keyring": {"eddsa": "${eddsaKey}"}}`;
+      const { result } = await zencode_exec(sign, { data, keys });
+      return {
+        "did-sign": JSON.parse(result).eddsa_signature,
+        "did-pk": String(user?.publicKey),
+      };
+    },
+    [user?.publicKey]
+  );
 
-  async function request<T>(method: string, path: string, body?: any): Promise<T> {
-    const url = `${DPP_BASE_URL}${path}`;
-    const jsonBody = body != null ? JSON.stringify(body) : undefined;
+  const request = useCallback(
+    async <T>(method: string, path: string, body?: any): Promise<T> => {
+      const url = `${DPP_BASE_URL}${path}`;
+      const jsonBody = body != null ? JSON.stringify(body) : undefined;
 
-    const headers: Record<string, string> = {};
+      const headers: Record<string, string> = {};
 
-    // Always send user ULID so backend can store/filter by it
-    if (user?.ulid) {
-      headers["x-user-id"] = user.ulid;
-    }
-
-    if (jsonBody) {
-      const authHeaders = await signBody(jsonBody);
-      Object.assign(headers, authHeaders);
-      headers["Content-Type"] = "application/json";
-    }
-
-    const res = await fetch(url, { method, headers, body: jsonBody });
-
-    if (!res.ok) {
-      let apiError: DppApiError = { error: res.statusText };
-      try {
-        apiError = await res.json();
-      } catch {
-        // response body may not be JSON
+      // Always send user ULID so backend can store/filter by it
+      if (user?.ulid) {
+        headers["x-user-id"] = user.ulid;
       }
-      throw new DppRequestError(apiError.error, res.status, apiError.details);
-    }
 
-    if (res.status === 204) return undefined as T;
-    return res.json();
-  }
+      if (jsonBody) {
+        const authHeaders = await signBody(jsonBody);
+        Object.assign(headers, authHeaders);
+        headers["Content-Type"] = "application/json";
+      }
+
+      const res = await fetch(url, { method, headers, body: jsonBody });
+
+      if (!res.ok) {
+        let apiError: DppApiError = { error: res.statusText };
+        try {
+          apiError = await res.json();
+        } catch {
+          // response body may not be JSON
+        }
+        throw new DppRequestError(apiError.error, res.status, apiError.details);
+      }
+
+      if (res.status === 204) return undefined as T;
+      return res.json();
+    },
+    [signBody, user?.ulid]
+  );
 
   // --- CRUD ---
 
-  async function createDpp(data: Omit<DppDocument, "id">): Promise<CreateDppResponse> {
-    return request<CreateDppResponse>("POST", "/dpp", data);
-  }
+  const createDpp = useCallback(
+    async (data: Omit<DppDocument, "id">): Promise<CreateDppResponse> => {
+      return request<CreateDppResponse>("POST", "/dpp", data);
+    },
+    [request]
+  );
 
-  async function getDpp(id: string): Promise<DppDocument> {
-    return request<DppDocument>("GET", `/dpp/${encodeURIComponent(id)}`);
-  }
+  const getDpp = useCallback(
+    async (id: string): Promise<DppDocument> => {
+      return request<DppDocument>("GET", `/dpp/${encodeURIComponent(id)}`);
+    },
+    [request]
+  );
 
-  async function updateDpp(id: string, data: Partial<DppDocument>): Promise<UpdateDppResponse> {
-    return request<UpdateDppResponse>("PUT", `/dpp/${encodeURIComponent(id)}`, data);
-  }
+  const updateDpp = useCallback(
+    async (id: string, data: Partial<DppDocument>): Promise<UpdateDppResponse> => {
+      return request<UpdateDppResponse>("PUT", `/dpp/${encodeURIComponent(id)}`, data);
+    },
+    [request]
+  );
 
-  async function deleteDpp(id: string): Promise<DeleteDppResponse> {
-    return request<DeleteDppResponse>("DELETE", `/dpp/${encodeURIComponent(id)}`);
-  }
+  const deleteDpp = useCallback(
+    async (id: string): Promise<DeleteDppResponse> => {
+      return request<DeleteDppResponse>("DELETE", `/dpp/${encodeURIComponent(id)}`);
+    },
+    [request]
+  );
 
   // --- List / Query ---
 
-  async function listDpps(filters?: ListDppsFilters): Promise<ListDppsResponse> {
-    const params = new URLSearchParams();
-    if (filters?.productId) params.set("productId", filters.productId);
-    if (filters?.createdBy) params.set("createdBy", filters.createdBy);
-    if (filters?.status) params.set("status", filters.status);
-    if (filters?.limit != null) params.set("limit", String(filters.limit));
-    if (filters?.offset != null) params.set("offset", String(filters.offset));
+  const listDpps = useCallback(
+    async (filters?: ListDppsFilters): Promise<ListDppsResponse> => {
+      const params = new URLSearchParams();
+      if (filters?.productId) params.set("productId", filters.productId);
+      if (filters?.createdBy) params.set("createdBy", filters.createdBy);
+      if (filters?.status) params.set("status", filters.status);
+      if (filters?.limit != null) params.set("limit", String(filters.limit));
+      if (filters?.offset != null) params.set("offset", String(filters.offset));
 
-    const qs = params.toString();
-    const path = qs ? `/dpps?${qs}` : "/dpps";
+      const qs = params.toString();
+      const path = qs ? `/dpps?${qs}` : "/dpps";
 
-    return request<ListDppsResponse>("GET", path);
-  }
+      return request<ListDppsResponse>("GET", path);
+    },
+    [request]
+  );
 
   // --- File operations ---
 
-  async function uploadFile(file: File): Promise<Attachment> {
-    const arrayBuffer = await file.arrayBuffer();
-    const hashBuffer = await crypto.subtle.digest("SHA-256", arrayBuffer);
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    const checksum = hashArray.map(b => b.toString(16).padStart(2, "0")).join("");
+  const uploadFile = useCallback(
+    async (file: File): Promise<Attachment> => {
+      const arrayBuffer = await file.arrayBuffer();
+      const hashBuffer = await crypto.subtle.digest("SHA-256", arrayBuffer);
+      const hashArray = Array.from(new Uint8Array(hashBuffer));
+      const checksum = hashArray.map(b => b.toString(16).padStart(2, "0")).join("");
 
-    const zencode_exec = (await import("zenroom")).zencode_exec;
-    const data = `{"gql": "${checksum}"}`;
-    const keys = `{"keyring": {"eddsa": "${getItem("eddsaPrivateKey")}"}}`;
-    const { result } = await zencode_exec(sign, { data, keys });
-    const signature = JSON.parse(result).eddsa_signature;
+      const zencode_exec = (await import("zenroom")).zencode_exec;
+      const eddsaKey = typeof window !== "undefined" ? window.localStorage.getItem("eddsaPrivateKey") || "" : "";
+      const data = `{"gql": "${checksum}"}`;
+      const keys = `{"keyring": {"eddsa": "${eddsaKey}"}}`;
+      const { result } = await zencode_exec(sign, { data, keys });
+      const signature = JSON.parse(result).eddsa_signature;
 
-    const formData = new FormData();
-    formData.append("file", file);
+      const formData = new FormData();
+      formData.append("file", file);
 
-    const res = await fetch(`${DPP_BASE_URL}/upload`, {
-      method: "POST",
-      headers: {
-        "did-pk": String(user?.publicKey),
-        "did-sign": signature,
-      },
-      body: formData,
-    });
-
-    if (!res.ok) {
-      let apiError: DppApiError = { error: res.statusText };
-      try {
-        apiError = await res.json();
-      } catch {}
-      throw new DppRequestError(apiError.error, res.status, apiError.details);
-    }
-
-    return res.json();
-  }
-
-  function getFileUrl(id: string): string {
-    return `${DPP_BASE_URL}/file/${encodeURIComponent(id)}`;
-  }
-
-  async function updateDppStatus(id: string, status: DppStatus): Promise<UpdateDppResponse> {
-    return request<UpdateDppResponse>("PUT", `/dpp/${encodeURIComponent(id)}/status`, { status });
-  }
-
-  async function addAttachment(dppId: string, section: string, file: File): Promise<Attachment> {
-    const arrayBuffer = await file.arrayBuffer();
-    const hashBuffer = await crypto.subtle.digest("SHA-256", arrayBuffer);
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    const checksum = hashArray.map(b => b.toString(16).padStart(2, "0")).join("");
-
-    const zencode_exec = (await import("zenroom")).zencode_exec;
-    const data = `{"gql": "${checksum}"}`;
-    const keys = `{"keyring": {"eddsa": "${getItem("eddsaPrivateKey")}"}}`;
-    const { result } = await zencode_exec(sign, { data, keys });
-    const signature = JSON.parse(result).eddsa_signature;
-
-    const formData = new FormData();
-    formData.append("file", file);
-
-    const res = await fetch(
-      `${DPP_BASE_URL}/dpp/${encodeURIComponent(dppId)}/attachments?section=${encodeURIComponent(section)}`,
-      {
+      const res = await fetch(`${DPP_BASE_URL}/upload`, {
         method: "POST",
         headers: {
           "did-pk": String(user?.publicKey),
           "did-sign": signature,
         },
         body: formData,
+      });
+
+      if (!res.ok) {
+        let apiError: DppApiError = { error: res.statusText };
+        try {
+          apiError = await res.json();
+        } catch {}
+        throw new DppRequestError(apiError.error, res.status, apiError.details);
       }
-    );
 
-    if (!res.ok) {
-      let apiError: DppApiError = { error: res.statusText };
-      try {
-        apiError = await res.json();
-      } catch {}
-      throw new DppRequestError(apiError.error, res.status, apiError.details);
-    }
+      return res.json();
+    },
+    [user?.publicKey]
+  );
 
-    return res.json();
-  }
+  const getFileUrl = useCallback((id: string): string => {
+    return `${DPP_BASE_URL}/file/${encodeURIComponent(id)}`;
+  }, []);
 
-  async function deleteAttachment(dppId: string, attachmentId: string): Promise<void> {
-    return request<void>("DELETE", `/dpp/${encodeURIComponent(dppId)}/attachments/${encodeURIComponent(attachmentId)}`);
-  }
+  const updateDppStatus = useCallback(
+    async (id: string, status: DppStatus): Promise<UpdateDppResponse> => {
+      return request<UpdateDppResponse>("PUT", `/dpp/${encodeURIComponent(id)}/status`, { status });
+    },
+    [request]
+  );
 
-  return {
-    createDpp,
-    getDpp,
-    updateDpp,
-    deleteDpp,
-    listDpps,
-    uploadFile,
-    getFileUrl,
-    updateDppStatus,
-    addAttachment,
-    deleteAttachment,
-  };
+  const addAttachment = useCallback(
+    async (dppId: string, section: string, file: File): Promise<Attachment> => {
+      const arrayBuffer = await file.arrayBuffer();
+      const hashBuffer = await crypto.subtle.digest("SHA-256", arrayBuffer);
+      const hashArray = Array.from(new Uint8Array(hashBuffer));
+      const checksum = hashArray.map(b => b.toString(16).padStart(2, "0")).join("");
+
+      const zencode_exec = (await import("zenroom")).zencode_exec;
+      const eddsaKey = typeof window !== "undefined" ? window.localStorage.getItem("eddsaPrivateKey") || "" : "";
+      const data = `{"gql": "${checksum}"}`;
+      const keys = `{"keyring": {"eddsa": "${eddsaKey}"}}`;
+      const { result } = await zencode_exec(sign, { data, keys });
+      const signature = JSON.parse(result).eddsa_signature;
+
+      const formData = new FormData();
+      formData.append("file", file);
+
+      const res = await fetch(
+        `${DPP_BASE_URL}/dpp/${encodeURIComponent(dppId)}/attachments?section=${encodeURIComponent(section)}`,
+        {
+          method: "POST",
+          headers: {
+            "did-pk": String(user?.publicKey),
+            "did-sign": signature,
+          },
+          body: formData,
+        }
+      );
+
+      if (!res.ok) {
+        let apiError: DppApiError = { error: res.statusText };
+        try {
+          apiError = await res.json();
+        } catch {}
+        throw new DppRequestError(apiError.error, res.status, apiError.details);
+      }
+
+      return res.json();
+    },
+    [user?.publicKey]
+  );
+
+  const deleteAttachment = useCallback(
+    async (dppId: string, attachmentId: string): Promise<void> => {
+      return request<void>(
+        "DELETE",
+        `/dpp/${encodeURIComponent(dppId)}/attachments/${encodeURIComponent(attachmentId)}`
+      );
+    },
+    [request]
+  );
+
+  return useMemo(
+    () => ({
+      createDpp,
+      getDpp,
+      updateDpp,
+      deleteDpp,
+      listDpps,
+      uploadFile,
+      getFileUrl,
+      updateDppStatus,
+      addAttachment,
+      deleteAttachment,
+    }),
+    [
+      createDpp,
+      getDpp,
+      updateDpp,
+      deleteDpp,
+      listDpps,
+      uploadFile,
+      getFileUrl,
+      updateDppStatus,
+      addAttachment,
+      deleteAttachment,
+    ]
+  );
 };
 
 export default useDppApi;

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "focus-trap-react": "^10.3.1",
     "graphql": "^15.10.1",
     "husky": "^8.0.3",
+    "jspdf": "^4.2.1",
+    "jspdf-autotable": "^5.0.7",
     "lint-staged": "^13.3.0",
     "mapbox-gl": "^2.15.0",
     "markdown-it": "^13.0.2",

--- a/pages/dpps/[id].tsx
+++ b/pages/dpps/[id].tsx
@@ -10,11 +10,12 @@ import {
 } from "@carbon/icons-react";
 import Layout from "components/layout/Layout";
 import useDppApi, { DppRequestError } from "lib/dpp";
+import { generateDppPdf } from "lib/dpp-pdf";
 import type { DppDocument } from "lib/dpp-types";
 import type { GetStaticPaths } from "next";
-import Link from "next/link";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { NextPageWithLayout } from "pages/_app";
 import { ReactElement, useEffect, useMemo, useRef, useState } from "react";
@@ -212,6 +213,18 @@ const DppDetailPage: NextPageWithLayout = () => {
     URL.revokeObjectURL(href);
   };
 
+  const [pdfGenerating, setPdfGenerating] = useState(false);
+
+  const onDownloadPdf = async () => {
+    if (!dpp || typeof window === "undefined" || pdfGenerating) return;
+    setPdfGenerating(true);
+    try {
+      generateDppPdf(dpp);
+    } finally {
+      setPdfGenerating(false);
+    }
+  };
+
   const sections = useMemo(() => {
     if (!dpp) return [];
     return sectionConfig
@@ -388,18 +401,20 @@ const DppDetailPage: NextPageWithLayout = () => {
                   </button>
                   <button
                     type="button"
-                    onClick={onDownloadJson}
+                    onClick={onDownloadPdf}
+                    disabled={pdfGenerating}
                     className="inline-flex items-center gap-2 px-4 py-2 border-none cursor-pointer transition-colors"
                     style={{
                       borderRadius: "var(--ifr-radius-sm)",
                       fontSize: "var(--ifr-fs-sm)",
-                      backgroundColor: "#E5B94E",
+                      backgroundColor: pdfGenerating ? "#c9a042" : "#E5B94E",
                       color: "#1a1a1a",
                       fontWeight: "var(--ifr-fw-medium)",
+                      opacity: pdfGenerating ? 0.7 : 1,
                     }}
                   >
                     <Download size={16} />
-                    {t("Download PDF")}
+                    {pdfGenerating ? t("Generating…") : t("Download PDF")}
                   </button>
                   <button
                     type="button"

--- a/pages/dpps/[id].tsx
+++ b/pages/dpps/[id].tsx
@@ -1,0 +1,630 @@
+import {
+  ArrowLeft,
+  Checkmark,
+  ChevronDown,
+  ChevronUp,
+  Download,
+  Launch,
+  OverflowMenuVertical,
+  Share,
+} from "@carbon/icons-react";
+import Layout from "components/layout/Layout";
+import useDppApi, { DppRequestError } from "lib/dpp";
+import type { DppDocument } from "lib/dpp-types";
+import type { GetStaticPaths } from "next";
+import Link from "next/link";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { useRouter } from "next/router";
+import { NextPageWithLayout } from "pages/_app";
+import { ReactElement, useEffect, useMemo, useRef, useState } from "react";
+
+function prettifyKey(key: string): string {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/_/g, " ")
+    .replace(/^./, first => first.toUpperCase());
+}
+
+function getFieldValue(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return null;
+    return value.map(getFieldValue).filter(Boolean).join(", ") || null;
+  }
+
+  if (typeof value === "object") {
+    const maybeTransformed = value as { value?: unknown; units?: unknown };
+    if (Object.prototype.hasOwnProperty.call(maybeTransformed, "value")) {
+      const scalar = getFieldValue(maybeTransformed.value);
+      if (!scalar) return null;
+      const units = typeof maybeTransformed.units === "string" ? maybeTransformed.units : null;
+      return units ? `${scalar} ${units}` : scalar;
+    }
+  }
+
+  return null;
+}
+
+function sectionFields(section: unknown): Array<{ label: string; value: string }> {
+  if (!section || typeof section !== "object" || Array.isArray(section)) return [];
+
+  return Object.entries(section)
+    .map(([key, raw]) => {
+      const value = getFieldValue(raw);
+      if (!value) return null;
+      return { label: prettifyKey(key), value };
+    })
+    .filter((field): field is { label: string; value: string } => field !== null);
+}
+
+const sectionConfig: Array<{ key: keyof DppDocument; title: string; subtitle: string; color: string }> = [
+  {
+    key: "productOverview",
+    title: "DPP Overview",
+    subtitle: "Basic product information and identification",
+    color: "#E87C1E",
+  },
+  {
+    key: "complianceAndStandards",
+    title: "Compliance & Standards",
+    subtitle: "Regulatory compliance information",
+    color: "#2E7D32",
+  },
+  {
+    key: "reparability",
+    title: "Reparability",
+    subtitle: "Repair instructions and spare parts availability",
+    color: "#1565C0",
+  },
+  {
+    key: "environmentalImpact",
+    title: "Environmental Impact",
+    subtitle: "Resource consumption and emissions data",
+    color: "#558B2F",
+  },
+  {
+    key: "certificates",
+    title: "Certificates",
+    subtitle: "Environmental and quality certifications",
+    color: "#6A1B9A",
+  },
+  {
+    key: "recyclability",
+    title: "Recyclability",
+    subtitle: "Material composition and recycling information",
+    color: "#00838F",
+  },
+  {
+    key: "energyUseAndEfficiency",
+    title: "Energy Use & Efficiency",
+    subtitle: "Battery and power specifications",
+    color: "#EF6C00",
+  },
+  {
+    key: "economicOperator",
+    title: "Economic Operator",
+    subtitle: "Manufacturer and company information",
+    color: "#4E342E",
+  },
+  {
+    key: "repairInformation",
+    title: "Information about the Repair",
+    subtitle: "Repair events and documentation",
+    color: "#1565C0",
+  },
+  {
+    key: "refurbishmentInformation",
+    title: "Information about the Refurbishment",
+    subtitle: "Refurbishment events and processes",
+    color: "#00695C",
+  },
+  {
+    key: "recyclingInformation",
+    title: "Information on the Recycling",
+    subtitle: "End-of-life recycling data",
+    color: "#37474F",
+  },
+  {
+    key: "consumerInformation",
+    title: "Consumer Information",
+    subtitle: "Product usage and safety details",
+    color: "#AD1457",
+  },
+  {
+    key: "dosageInstructions",
+    title: "Dosage Instructions",
+    subtitle: "Application and dosage guidance",
+    color: "#C62828",
+  },
+  { key: "ingredients", title: "Ingredients", subtitle: "Ingredient and substance listing", color: "#283593" },
+  { key: "packaging", title: "Packaging", subtitle: "Packaging materials and specifications", color: "#795548" },
+];
+
+const DppDetailPage: NextPageWithLayout = () => {
+  const { t } = useTranslation("common");
+  const router = useRouter();
+  const dppApi = useDppApi();
+  const [dpp, setDpp] = useState<DppDocument | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const dppId = typeof router.query.id === "string" ? router.query.id : "";
+
+  useEffect(() => {
+    if (!router.isReady || !dppId) return;
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    dppApi
+      .getDpp(dppId)
+      .then(doc => {
+        if (!cancelled) setDpp(doc);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        if (err instanceof DppRequestError && err.status === 404) {
+          setDpp(null);
+          setError("not-found");
+          return;
+        }
+        setError("generic");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [dppApi, dppId, router.isReady]);
+
+  const dppTitle = dpp?.productOverview?.productName?.value || dpp?.batchId || dpp?.id || dppId;
+  const createdAt = dpp?.createdAt ? new Date(dpp.createdAt).toLocaleDateString() : "-";
+  const parentProductLabel = dpp?.productId || t("Unknown product");
+  const breadcrumbSeparator = "/";
+
+  const onShare = async () => {
+    const url = typeof window !== "undefined" ? window.location.href : "";
+    if (typeof navigator !== "undefined" && navigator.share) {
+      await navigator.share({ title: dppTitle, text: t("Digital Product Passport"), url });
+      return;
+    }
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(url);
+    }
+  };
+
+  const onDownloadJson = () => {
+    if (!dpp || typeof window === "undefined") return;
+    const blob = new Blob([JSON.stringify(dpp, null, 2)], { type: "application/json" });
+    const href = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = href;
+    anchor.download = `${dpp.id}.json`;
+    anchor.click();
+    URL.revokeObjectURL(href);
+  };
+
+  const sections = useMemo(() => {
+    if (!dpp) return [];
+    return sectionConfig
+      .map(config => {
+        const fields = sectionFields(dpp[config.key]);
+        if (fields.length === 0) return null;
+        return { key: String(config.key), title: config.title, subtitle: config.subtitle, color: config.color, fields };
+      })
+      .filter(Boolean) as Array<{
+      key: string;
+      title: string;
+      subtitle: string;
+      color: string;
+      fields: Array<{ label: string; value: string }>;
+    }>;
+  }, [dpp]);
+
+  const [dppInfoOpen, setDppInfoOpen] = useState(true);
+  const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({});
+
+  const scrollToSection = (key: string) => {
+    sectionRefs.current[key]?.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  const dppIcon = (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M12 2L3 7v10l9 5 9-5V7l-9-5zm0 2.18L18.36 7.5 12 10.82 5.64 7.5 12 4.18zM5 8.82l6 3.33v7.03l-6-3.33V8.82zm8 10.36V12.15l6-3.33v7.03l-6 3.33z"
+        fill="#E87C1E"
+      />
+    </svg>
+  );
+
+  return (
+    <div className="flex-1 bg-ifr-page" style={{ fontFamily: "var(--ifr-font-body)" }}>
+      <div className="max-w-[1180px] mx-auto px-6 py-8 flex flex-col gap-6">
+        <Link href="/products">
+          <a className="inline-flex items-center gap-2 no-underline text-ifr-text-secondary hover:text-ifr-text-primary">
+            <ArrowLeft size={16} />
+            {t("Back")}
+          </a>
+        </Link>
+
+        {loading && (
+          <div className="bg-ifr-surface border border-ifr rounded-ifr-md p-10 text-center text-ifr-text-secondary">
+            {t("Loading DPP details...")}
+          </div>
+        )}
+
+        {!loading && error === "not-found" && (
+          <div className="bg-ifr-surface border border-ifr rounded-ifr-md p-10 text-center">
+            <h1
+              className="m-0 text-ifr-text-primary"
+              style={{ fontSize: "var(--ifr-fs-xl)", fontWeight: "var(--ifr-fw-bold)" }}
+            >
+              {t("DPP not found")}
+            </h1>
+            <p className="mt-3 mb-0 text-ifr-text-secondary">
+              {t("This Digital Product Passport does not exist or is no longer available.")}
+            </p>
+          </div>
+        )}
+
+        {!loading && error === "generic" && (
+          <div className="bg-ifr-surface border border-ifr rounded-ifr-md p-10 text-center">
+            <h1
+              className="m-0 text-ifr-text-primary"
+              style={{ fontSize: "var(--ifr-fs-xl)", fontWeight: "var(--ifr-fw-bold)" }}
+            >
+              {t("Unable to load DPP")}
+            </h1>
+            <p className="mt-3 mb-4 text-ifr-text-secondary">{t("An error occurred while loading the DPP details.")}</p>
+            <button
+              type="button"
+              onClick={() => router.replace(router.asPath)}
+              className="px-4 py-2 bg-ifr-yellow border-none rounded-ifr-sm cursor-pointer"
+            >
+              {t("Retry")}
+            </button>
+          </div>
+        )}
+
+        {!loading && !error && dpp && (
+          <>
+            {/* Breadcrumbs */}
+            <nav className="text-ifr-text-secondary" style={{ fontSize: "var(--ifr-fs-sm)" }}>
+              <Link href="/products">
+                <a className="text-ifr-text-secondary no-underline hover:underline">{t("Products")}</a>
+              </Link>
+              <span> {breadcrumbSeparator} </span>
+              {dpp.productId ? (
+                <Link href={`/project/${encodeURIComponent(dpp.productId)}`}>
+                  <a className="text-ifr-text-secondary no-underline hover:underline">{parentProductLabel}</a>
+                </Link>
+              ) : (
+                <span>{parentProductLabel}</span>
+              )}
+              <span> {breadcrumbSeparator} </span>
+              <span className="text-ifr-text-primary">{dpp.id}</span>
+            </nav>
+
+            {/* Header card */}
+            <div className="bg-ifr-surface border border-ifr rounded-ifr-md p-6 flex flex-col gap-4">
+              {/* Top row: label + actions */}
+              <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-3">
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center gap-2">
+                    {dppIcon}
+                    <span
+                      style={{ color: "#E87C1E", fontSize: "var(--ifr-fs-sm)", fontWeight: "var(--ifr-fw-medium)" }}
+                    >
+                      {t("Digital Product Passport")}
+                    </span>
+                  </div>
+                  <div className="flex items-center gap-3 flex-wrap">
+                    <h1
+                      className="m-0 text-ifr-text-primary"
+                      style={{ fontSize: "var(--ifr-fs-2xl)", fontWeight: "var(--ifr-fw-bold)" }}
+                    >
+                      {dppTitle}
+                    </h1>
+                    <span
+                      className="inline-flex items-center gap-1 px-2.5 py-0.5"
+                      style={{
+                        borderRadius: "999px",
+                        backgroundColor: dpp.status === "active" ? "rgba(46,125,50,0.1)" : "rgba(3,106,83,0.1)",
+                        color: dpp.status === "active" ? "#2E7D32" : "#036A53",
+                        fontSize: "var(--ifr-fs-xs)",
+                        fontWeight: "var(--ifr-fw-medium)",
+                      }}
+                    >
+                      {dpp.status === "active" && (
+                        <span
+                          style={{
+                            width: 6,
+                            height: 6,
+                            borderRadius: "50%",
+                            backgroundColor: "#2E7D32",
+                            display: "inline-block",
+                          }}
+                        />
+                      )}
+                      {(dpp.status || "draft").charAt(0).toUpperCase() + (dpp.status || "draft").slice(1)}
+                    </span>
+                  </div>
+                  {dpp.batchId && (
+                    <div className="flex items-center gap-2" style={{ fontSize: "var(--ifr-fs-sm)" }}>
+                      <span className="text-ifr-text-secondary">{t("Batch") + ":"}</span>
+                      <code
+                        className="text-ifr-text-primary"
+                        style={{
+                          padding: "2px 8px",
+                          backgroundColor: "rgba(0,0,0,0.05)",
+                          borderRadius: "var(--ifr-radius-sm)",
+                          fontSize: "var(--ifr-fs-sm)",
+                        }}
+                      >
+                        {dpp.batchId}
+                      </code>
+                    </div>
+                  )}
+                </div>
+
+                {/* Action buttons */}
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  <button
+                    type="button"
+                    onClick={onShare}
+                    className="inline-flex items-center gap-2 px-4 py-2 bg-transparent border border-ifr hover:bg-ifr-hover transition-colors cursor-pointer"
+                    style={{ borderRadius: "var(--ifr-radius-sm)", fontSize: "var(--ifr-fs-sm)" }}
+                  >
+                    <Share size={16} />
+                    {t("Share")}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={onDownloadJson}
+                    className="inline-flex items-center gap-2 px-4 py-2 border-none cursor-pointer transition-colors"
+                    style={{
+                      borderRadius: "var(--ifr-radius-sm)",
+                      fontSize: "var(--ifr-fs-sm)",
+                      backgroundColor: "#E5B94E",
+                      color: "#1a1a1a",
+                      fontWeight: "var(--ifr-fw-medium)",
+                    }}
+                  >
+                    <Download size={16} />
+                    {t("Download PDF")}
+                  </button>
+                  <button
+                    type="button"
+                    className="inline-flex items-center justify-center w-9 h-9 bg-transparent border border-ifr hover:bg-ifr-hover transition-colors cursor-pointer"
+                    style={{ borderRadius: "var(--ifr-radius-sm)" }}
+                    aria-label={t("More actions")}
+                  >
+                    <OverflowMenuVertical size={16} />
+                  </button>
+                </div>
+              </div>
+
+              {/* Product link row */}
+              <div
+                className="flex flex-col md:flex-row md:items-center md:justify-between gap-2 pt-3"
+                style={{ borderTop: "1px solid var(--ifr-border-color, #e0e0e0)" }}
+              >
+                <div className="flex items-center gap-2">
+                  <span className="text-ifr-text-secondary" style={{ fontSize: "var(--ifr-fs-sm)" }}>
+                    {t("Product") + ":"}
+                  </span>
+                  {dpp.productId ? (
+                    <Link href={`/project/${encodeURIComponent(dpp.productId)}`}>
+                      <a
+                        className="inline-flex items-center gap-1 no-underline hover:underline"
+                        style={{ color: "#1565C0" }}
+                      >
+                        <Launch size={14} />
+                        {parentProductLabel}
+                      </a>
+                    </Link>
+                  ) : (
+                    <span className="text-ifr-text-primary">{t("Not linked")}</span>
+                  )}
+                </div>
+                <span className="text-ifr-text-secondary" style={{ fontSize: "var(--ifr-fs-sm)" }}>
+                  {t("Published")} {createdAt}
+                </span>
+              </div>
+            </div>
+
+            {/* "What is a DPP?" explainer card */}
+            <div className="bg-ifr-surface border border-ifr rounded-ifr-md">
+              <button
+                type="button"
+                onClick={() => setDppInfoOpen(prev => !prev)}
+                className="w-full flex items-center justify-between px-6 py-4 bg-transparent border-none cursor-pointer text-left"
+              >
+                <div className="flex items-center gap-3">
+                  {dppIcon}
+                  <span
+                    className="text-ifr-text-primary"
+                    style={{ fontSize: "var(--ifr-fs-lg)", fontWeight: "var(--ifr-fw-bold)" }}
+                  >
+                    {t("What is a Digital Product Passport?")}
+                  </span>
+                </div>
+                {dppInfoOpen ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
+              </button>
+              {dppInfoOpen && (
+                <div className="px-6 pb-5" style={{ fontSize: "var(--ifr-fs-sm)", lineHeight: 1.6 }}>
+                  <p className="m-0 mb-3 text-ifr-text-secondary">
+                    {t(
+                      "A Digital Product Passport (DPP) is a structured digital record that travels with a product throughout its entire lifecycle — from manufacturing to end-of-life. It provides transparent, verifiable information about sustainability, compliance, repairability, and recyclability."
+                    )}
+                  </p>
+                  <ul className="m-0 p-0 flex flex-col gap-2" style={{ listStyle: "none" }}>
+                    {[
+                      t("Traceability — records who made the product, where, and with what materials"),
+                      t("Circularity support — enables repair, refurbishment, and responsible recycling"),
+                      t("Regulatory compliance — documents CE marking, RoHS, and other certifications"),
+                      t("Consumer transparency — gives buyers verified data on the product they purchased"),
+                    ].map(item => (
+                      <li key={item} className="flex items-start gap-2 text-ifr-text-secondary">
+                        <Checkmark size={16} className="flex-shrink-0 mt-0.5" style={{ color: "#2E7D32" }} />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+
+            {/* Two-column: sections + sidebar */}
+            <div className="flex gap-6 items-start">
+              {/* Sections column */}
+              <div className="flex-1 min-w-0 flex flex-col gap-4">
+                {sections.length === 0 ? (
+                  <div className="bg-ifr-surface border border-ifr rounded-ifr-md p-8 text-ifr-text-secondary">
+                    {t("No section data available for this DPP.")}
+                  </div>
+                ) : (
+                  sections.map(section => (
+                    <div
+                      key={section.key}
+                      ref={el => {
+                        sectionRefs.current[section.key] = el;
+                      }}
+                      className="bg-ifr-surface border border-ifr rounded-ifr-md"
+                    >
+                      {/* Section header with colored icon */}
+                      <div
+                        className="flex items-center gap-3 px-6 py-4"
+                        style={{ borderBottom: "1px solid var(--ifr-border-color, #e0e0e0)" }}
+                      >
+                        <div
+                          className="flex-shrink-0 flex items-center justify-center"
+                          style={{
+                            width: 36,
+                            height: 36,
+                            borderRadius: "50%",
+                            backgroundColor: `${section.color}18`,
+                          }}
+                        >
+                          <svg
+                            width="18"
+                            height="18"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M12 2L3 7v10l9 5 9-5V7l-9-5zm0 2.18L18.36 7.5 12 10.82 5.64 7.5 12 4.18zM5 8.82l6 3.33v7.03l-6-3.33V8.82zm8 10.36V12.15l6-3.33v7.03l-6 3.33z"
+                              fill={section.color}
+                            />
+                          </svg>
+                        </div>
+                        <div>
+                          <p
+                            className="m-0 text-ifr-text-primary"
+                            style={{ fontSize: "var(--ifr-fs-base)", fontWeight: "var(--ifr-fw-bold)" }}
+                          >
+                            {t(section.title)}
+                          </p>
+                          <p className="m-0 text-ifr-text-secondary" style={{ fontSize: "var(--ifr-fs-xs)" }}>
+                            {t(section.subtitle)}
+                          </p>
+                        </div>
+                      </div>
+                      {/* Section fields */}
+                      <div className="grid gap-4 md:grid-cols-2 p-6">
+                        {section.fields.map(field => (
+                          <div key={`${section.key}-${field.label}`}>
+                            <p className="m-0 text-ifr-text-secondary" style={{ fontSize: "var(--ifr-fs-xs)" }}>
+                              {t(field.label)}
+                            </p>
+                            <p className="m-0 text-ifr-text-primary" style={{ fontSize: "var(--ifr-fs-base)" }}>
+                              {field.value}
+                            </p>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+
+              {/* Sidebar navigation (desktop only) */}
+              {sections.length > 0 && (
+                <div className="hidden lg:block w-[260px] flex-shrink-0 sticky top-8">
+                  <div className="bg-ifr-surface border border-ifr rounded-ifr-md p-4 flex flex-col gap-1">
+                    {sections.map(section => (
+                      <button
+                        key={section.key}
+                        type="button"
+                        onClick={() => scrollToSection(section.key)}
+                        className="flex items-center gap-2.5 px-3 py-2 bg-transparent border-none cursor-pointer text-left rounded hover:bg-ifr-hover transition-colors w-full"
+                        style={{ fontSize: "var(--ifr-fs-sm)" }}
+                      >
+                        <div
+                          className="flex-shrink-0 flex items-center justify-center"
+                          style={{
+                            width: 24,
+                            height: 24,
+                            borderRadius: "50%",
+                            backgroundColor: `${section.color}18`,
+                          }}
+                        >
+                          <svg
+                            width="12"
+                            height="12"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M12 2L3 7v10l9 5 9-5V7l-9-5zm0 2.18L18.36 7.5 12 10.82 5.64 7.5 12 4.18zM5 8.82l6 3.33v7.03l-6-3.33V8.82zm8 10.36V12.15l6-3.33v7.03l-6 3.33z"
+                              fill={section.color}
+                            />
+                          </svg>
+                        </div>
+                        <span className="text-ifr-text-primary">{t(section.title)}</span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const getStaticPaths: GetStaticPaths<{ id: string }> = async () => {
+  return {
+    paths: [],
+    fallback: "blocking",
+  };
+};
+
+export async function getStaticProps({ locale }: { locale: string }) {
+  return {
+    props: {
+      publicPage: true,
+      ...(await serverSideTranslations(locale, ["common"])),
+    },
+  };
+}
+
+DppDetailPage.publicPage = true;
+
+DppDetailPage.getLayout = function getLayout(page: ReactElement) {
+  return <Layout bottomPadding="none">{page}</Layout>;
+};
+
+export default DppDetailPage;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,12 @@ importers:
       husky:
         specifier: ^8.0.3
         version: 8.0.3
+      jspdf:
+        specifier: ^4.2.1
+        version: 4.2.1
+      jspdf-autotable:
+        specifier: ^5.0.7
+        version: 5.0.7(jspdf@4.2.1)
       lint-staged:
         specifier: ^13.3.0
         version: 13.3.0
@@ -571,6 +577,10 @@ packages:
 
   '@babel/runtime@7.28.4':
     resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
@@ -1455,6 +1465,9 @@ packages:
   '@types/node@18.7.15':
     resolution: {integrity: sha512-XnjpaI8Bgc3eBag2Aw4t2Uj/49lLBSStHWfqKvIuXD7FIrZyMLWp8KuAFHAqxMZYTF9l08N1ctUn9YNybZJVmQ==}
 
+  '@types/pako@2.0.4':
+    resolution: {integrity: sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==}
+
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
@@ -1466,6 +1479,9 @@ packages:
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/raf@3.4.3':
+    resolution: {integrity: sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==}
 
   '@types/react-dom@18.0.6':
     resolution: {integrity: sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==}
@@ -1483,6 +1499,9 @@ packages:
 
   '@types/semver@7.7.1':
     resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -1822,6 +1841,10 @@ packages:
   base45@2.0.1:
     resolution: {integrity: sha512-Cr2mmczMfOQSkt9OyzpUpUNWKCurLpYhCjkN+yPXicjEc47gkN9LbklR3c7dUrpcPonjoAyZp7bZQChRRg4G1Q==}
 
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -1924,6 +1947,10 @@ packages:
 
   caniuse-lite@1.0.30001749:
     resolution: {integrity: sha512-0rw2fJOmLfnzCRbkm8EyHL8SvI2Apu5UbnQuTsJ0ClgrH8hcwFooJ1s5R0EP8o8aVrFu8++ae29Kt9/gZAZp/Q==}
+
+  canvg@3.0.11:
+    resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
+    engines: {node: '>=10.0.0'}
 
   capital-case@1.0.4:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
@@ -2106,6 +2133,9 @@ packages:
     hasBin: true
     peerDependencies:
       postcss: ^8.4
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   css-prefers-color-scheme@6.0.3:
     resolution: {integrity: sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==}
@@ -2334,6 +2364,9 @@ packages:
 
   dom7@4.0.6:
     resolution: {integrity: sha512-emjdpPLhpNubapLFdjNL9tP06Sr+GZkrIHEXLWvOGsytACUrkbeIdjO5g77m00BrHTznnlcNqgmn7pCN192TBA==}
+
+  dompurify@3.4.0:
+    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -2617,6 +2650,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-png@6.4.0:
+    resolution: {integrity: sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==}
+
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
@@ -2637,6 +2673,9 @@ packages:
 
   fbjs@3.0.5:
     resolution: {integrity: sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==}
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   figures@3.2.0:
     resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
@@ -2926,6 +2965,10 @@ packages:
   html-void-elements@2.0.1:
     resolution: {integrity: sha512-0quDb7s97CfemeJAnW9wC0hw78MtW7NU3hqtCD75g2vFlDLt36llsYD7uB7SUzojLMP24N5IatXf7ylGXiGG9A==}
 
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
+
   http-proxy-agent@6.1.1:
     resolution: {integrity: sha512-JRCz+4Whs6yrrIoIlrH+ZTmhrRwtMnmOHsHn8GFEn9O2sVfSE+DAZ3oyyGIKF8tjJEeSJmP89j7aTjVsSqsU0g==}
     engines: {node: '>= 14'}
@@ -3007,6 +3050,9 @@ packages:
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
+  iobuffer@5.4.0:
+    resolution: {integrity: sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==}
 
   is-absolute@1.0.0:
     resolution: {integrity: sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==}
@@ -3290,6 +3336,14 @@ packages:
   jsonwebtoken@9.0.2:
     resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
     engines: {node: '>=12', npm: '>=6'}
+
+  jspdf-autotable@5.0.7:
+    resolution: {integrity: sha512-2wr7H6liNDBYNwt25hMQwXkEWFOEopgKIvR1Eukuw6Zmprm/ZcnmLTQEjW7Xx3FCbD3v7pflLcnMAv/h1jFDQw==}
+    peerDependencies:
+      jspdf: ^2 || ^3 || ^4
+
+  jspdf@4.2.1:
+    resolution: {integrity: sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==}
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -3891,6 +3945,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@2.1.0:
+    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
+
   param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
 
@@ -3962,6 +4019,9 @@ packages:
   pbf@3.3.0:
     resolution: {integrity: sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==}
     hasBin: true
+
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -4297,6 +4357,9 @@ packages:
   quickselect@2.0.0:
     resolution: {integrity: sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==}
 
+  raf@3.4.1:
+    resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
+
   react-base16-styling@0.6.0:
     resolution: {integrity: sha512-yvh/7CArceR/jNATXOKDlvTnPKPmGZz7zsenQ3jUwLzHkNUR0CvY3yGYJbWJ/nnxsL8Sgmt5cO3/SILVuPO6TQ==}
 
@@ -4439,6 +4502,9 @@ packages:
   refractor@4.9.0:
     resolution: {integrity: sha512-nEG1SPXFoGGx+dcjftjv8cAjEusIh6ED1xhf5DG3C0x/k+rmZ2duKnc3QLpt6qeHv5fPb8uwN3VWN2BT7fr3Og==}
 
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
@@ -4547,6 +4613,10 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rgbcolor@1.0.1:
+    resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
+    engines: {node: '>= 0.8.15'}
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
@@ -4731,6 +4801,10 @@ packages:
   ssr-window@4.0.2:
     resolution: {integrity: sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ==}
 
+  stackblur-canvas@2.7.0:
+    resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
+    engines: {node: '>=0.1.14'}
+
   start-server-and-test@1.15.5:
     resolution: {integrity: sha512-o3EmkX0++GV+qsvIJ/OKWm3w91fD8uS/bPQVPrh/7loaxkpXSuAIHdnmN/P/regQK9eNAK76aBJcHt+OSTk+nA==}
     engines: {node: '>=6'}
@@ -4848,6 +4922,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svg-pathdata@6.0.3:
+    resolution: {integrity: sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==}
+    engines: {node: '>=12.0.0'}
+
   swap-case@2.0.2:
     resolution: {integrity: sha512-kc6S2YS/2yXbtkSMunBtKdah4VFETZ8Oh6ONSmSd9bRxhqTrtARUCBUiWXH3xVPpvR7tz2CSnkuXVE42EcGnMw==}
 
@@ -4875,6 +4953,9 @@ packages:
     resolution: {integrity: sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -5119,6 +5200,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -5667,6 +5751,8 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
 
   '@babel/runtime@7.28.4': {}
+
+  '@babel/runtime@7.29.2': {}
 
   '@babel/template@7.27.2':
     dependencies:
@@ -6817,6 +6903,8 @@ snapshots:
 
   '@types/node@18.7.15': {}
 
+  '@types/pako@2.0.4': {}
+
   '@types/parse-json@4.0.2': {}
 
   '@types/parse5@6.0.3': {}
@@ -6824,6 +6912,9 @@ snapshots:
   '@types/prismjs@1.26.5': {}
 
   '@types/prop-types@15.7.15': {}
+
+  '@types/raf@3.4.3':
+    optional: true
 
   '@types/react-dom@18.0.6':
     dependencies:
@@ -6842,6 +6933,9 @@ snapshots:
   '@types/scheduler@0.26.0': {}
 
   '@types/semver@7.7.1': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/unist@2.0.11': {}
 
@@ -7289,6 +7383,9 @@ snapshots:
 
   base45@2.0.1: {}
 
+  base64-arraybuffer@1.0.2:
+    optional: true
+
   base64-js@1.5.1: {}
 
   base64url@3.0.1: {}
@@ -7391,6 +7488,18 @@ snapshots:
   camelcase@5.3.1: {}
 
   caniuse-lite@1.0.30001749: {}
+
+  canvg@3.0.11:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@types/raf': 3.4.3
+      core-js: 3.45.1
+      raf: 3.4.1
+      regenerator-runtime: 0.13.11
+      rgbcolor: 1.0.1
+      stackblur-canvas: 2.7.0
+      svg-pathdata: 6.0.3
+    optional: true
 
   capital-case@1.0.4:
     dependencies:
@@ -7587,6 +7696,11 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
+    optional: true
+
   css-prefers-color-scheme@6.0.3(postcss@8.5.6):
     dependencies:
       postcss: 8.5.6
@@ -7772,6 +7886,11 @@ snapshots:
   dom7@4.0.6:
     dependencies:
       ssr-window: 4.0.2
+
+  dompurify@3.4.0:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+    optional: true
 
   dot-case@3.0.4:
     dependencies:
@@ -8209,6 +8328,12 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-png@6.4.0:
+    dependencies:
+      '@types/pako': 2.0.4
+      iobuffer: 5.4.0
+      pako: 2.1.0
+
   fast-querystring@1.1.2:
     dependencies:
       fast-decode-uri-component: 1.0.1
@@ -8244,6 +8369,8 @@ snapshots:
       ua-parser-js: 1.0.41
     transitivePeerDependencies:
       - encoding
+
+  fflate@0.8.2: {}
 
   figures@3.2.0:
     dependencies:
@@ -8604,6 +8731,12 @@ snapshots:
 
   html-void-elements@2.0.1: {}
 
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
+    optional: true
+
   http-proxy-agent@6.1.1:
     dependencies:
       agent-base: 7.1.4
@@ -8691,6 +8824,8 @@ snapshots:
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
+
+  iobuffer@5.4.0: {}
 
   is-absolute@1.0.0:
     dependencies:
@@ -8970,6 +9105,21 @@ snapshots:
       lodash.once: 4.1.1
       ms: 2.1.3
       semver: 7.7.3
+
+  jspdf-autotable@5.0.7(jspdf@4.2.1):
+    dependencies:
+      jspdf: 4.2.1
+
+  jspdf@4.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      fast-png: 6.4.0
+      fflate: 0.8.2
+    optionalDependencies:
+      canvg: 3.0.11
+      core-js: 3.45.1
+      dompurify: 3.4.0
+      html2canvas: 1.4.1
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -9780,6 +9930,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@2.1.0: {}
+
   param-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
@@ -9857,6 +10009,9 @@ snapshots:
     dependencies:
       ieee754: 1.2.1
       resolve-protobuf-schema: 2.1.0
+
+  performance-now@2.1.0:
+    optional: true
 
   picocolors@1.1.1: {}
 
@@ -10170,6 +10325,11 @@ snapshots:
 
   quickselect@2.0.0: {}
 
+  raf@3.4.1:
+    dependencies:
+      performance-now: 2.1.0
+    optional: true
+
   react-base16-styling@0.6.0:
     dependencies:
       base16: 1.0.0
@@ -10371,6 +10531,9 @@ snapshots:
       hastscript: 7.2.0
       parse-entities: 4.0.2
 
+  regenerator-runtime@0.13.11:
+    optional: true
+
   regexp.prototype.flags@1.5.4:
     dependencies:
       call-bind: 1.0.8
@@ -10521,6 +10684,9 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  rgbcolor@1.0.1:
+    optional: true
 
   rimraf@3.0.2:
     dependencies:
@@ -10725,6 +10891,9 @@ snapshots:
 
   ssr-window@4.0.2: {}
 
+  stackblur-canvas@2.7.0:
+    optional: true
+
   start-server-and-test@1.15.5:
     dependencies:
       arg: 5.0.2
@@ -10867,6 +11036,9 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svg-pathdata@6.0.3:
+    optional: true
+
   swap-case@2.0.2:
     dependencies:
       tslib: 2.8.1
@@ -10915,6 +11087,11 @@ snapshots:
     transitivePeerDependencies:
       - tsx
       - yaml
+
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+    optional: true
 
   text-table@0.2.0: {}
 
@@ -11173,6 +11350,11 @@ snapshots:
       react: 18.2.0
 
   util-deprecate@1.0.2: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
+    optional: true
 
   uuid@8.3.2: {}
 


### PR DESCRIPTION
- Add /dpps/[id] route with SSG fallback and public access
- Header card: orange DPP icon, inline status badge, batch code,
  Share/Download PDF/overflow action buttons
- Collapsible 'What is a DPP?' explainer card with checkmarks
- Sticky sidebar with colored section navigation (desktop)
- Section cards with colored icon headers, title+subtitle, field grids
- Product detail DPP cards navigate to /dpps/{id}
- Profile DPP tab rows navigate to /dpps/{id} with keyboard support
- Fix useDppApi infinite re-render: bypass unstable useStorage refs,
  read localStorage directly in useCallback bodies

Closes: interfacer-gui-7yb.1, .2, .3, .4, .6, .7, .8, .9
