### PR TITLE
fix(nav): 🐛 Designs links to /designs, fix active state catch-all

### DIFF
--- a/.beads/last-touched
+++ b/.beads/last-touched
@@ -1,1 +1,1 @@
-interfacer-gui-24l.7
+interfacer-gui-vom.5

--- a/components/NavigationMenu.tsx
+++ b/components/NavigationMenu.tsx
@@ -229,11 +229,15 @@ export default function NavigationMenu({ open, onClose }: NavigationMenuProps) {
 
           <NavItem
             icon={
-              <EntityTypeIcon type={ProjectType.DESIGN} size="small" fill={entityIconColor("/", "var(--ifr-green)")} />
+              <EntityTypeIcon
+                type={ProjectType.DESIGN}
+                size="small"
+                fill={entityIconColor("/designs", "var(--ifr-green)")}
+              />
             }
             label={t("Designs", "Designs")}
-            active={isActive("/")}
-            onClick={() => handleNavigate("/")}
+            active={isActive("/designs")}
+            onClick={() => handleNavigate("/designs")}
             activeBg="var(--ifr-stat-green-bg)"
             activeTextColor="var(--ifr-green)"
           />

--- a/components/partials/topbar/Topbar.tsx
+++ b/components/partials/topbar/Topbar.tsx
@@ -65,10 +65,10 @@ function Topbar({ search = true, userMenu = true, cta, burger = true }: topbarPr
     [searchString, router]
   );
 
-  // Active nav link detection
-  const isDesigns = path === "/" || (path.startsWith("/products") === false && path.startsWith("/services") === false);
-  const isProducts = path.startsWith("/products");
-  const isServices = path.startsWith("/services");
+  // Active nav link detection — exact catalog matching, no fallback
+  const isDesigns = path === "/designs" || path.startsWith("/designs/");
+  const isProducts = path === "/products" || path.startsWith("/products/");
+  const isServices = path === "/services" || path.startsWith("/services/");
 
   return (
     <>
@@ -115,7 +115,7 @@ function Topbar({ search = true, userMenu = true, cta, burger = true }: topbarPr
 
           {/* Navigation links */}
           <nav className="hidden md:flex items-center gap-6 ml-2">
-            <Link href="/">
+            <Link href="/designs">
               <a
                 className={`no-underline whitespace-nowrap px-3 py-1.5 transition-colors ${
                   isDesigns


### PR DESCRIPTION
- Topbar: Designs nav button links to /designs instead of /
- Topbar: active state uses exact path matching, no fallback
- NavigationMenu: Designs sidebar link updated to /designs
- Logo still links to / homepage
