### PR TITLE
refactor(ui): remove redundant owner banners and fix search filters

### DIFF
--- a/components/ProfilePageNew.tsx
+++ b/components/ProfilePageNew.tsx
@@ -112,15 +112,23 @@ function ProfileTabContent({
 }) {
   const { t } = useTranslation("common");
   const [searchQuery, setSearchQuery] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
   const [sortBy, setSortBy] = useState("latest");
   const [showSortMenu, setShowSortMenu] = useState(false);
+
+  // Debounce search input to avoid firing a query on every keystroke
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(searchQuery), 300);
+    return () => clearTimeout(timer);
+  }, [searchQuery]);
 
   const filter = useMemo(
     () => ({
       primaryAccountable: [userId],
       conformsTo: specId ? [specId] : undefined,
+      ...(debouncedSearch && { name: debouncedSearch }),
     }),
-    [userId, specId]
+    [userId, specId, debouncedSearch]
   );
 
   const dataQueryIdentifier = "economicResources";

--- a/pages/profile/[id]/index.tsx
+++ b/pages/profile/[id]/index.tsx
@@ -16,7 +16,6 @@
 
 import FetchUserLayout from "components/layout/FetchUserLayout";
 import Layout from "components/layout/Layout";
-import EditProfileBanner from "components/partials/profile/[id]/EditProfileBanner";
 import ProfilePageNew from "components/ProfilePageNew";
 import type { GetStaticPaths } from "next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -25,12 +24,7 @@ import { NextPageWithLayout } from "pages/_app";
 //
 
 const Profile: NextPageWithLayout = () => {
-  return (
-    <>
-      <EditProfileBanner />
-      <ProfilePageNew />
-    </>
-  );
+  return <ProfilePageNew />;
 };
 
 export const getStaticPaths: GetStaticPaths<{ slug: string }> = async () => {

--- a/pages/project/[id]/index.tsx
+++ b/pages/project/[id]/index.tsx
@@ -21,7 +21,6 @@ import { createContext, Dispatch, ReactElement, SetStateAction, useContext, useM
 
 import FetchProjectLayout, { useProject } from "components/layout/FetchProjectLayout";
 import Layout from "components/layout/Layout";
-import EditBanner from "components/partials/project/[id]/EditBanner";
 import SuccessBanner from "components/partials/project/[id]/SuccessBanner";
 import ProjectDetailNew from "components/ProjectDetailNew";
 import findProjectImages from "lib/findProjectImages";
@@ -82,7 +81,6 @@ const Project: NextPageWithLayout = () => {
       />
       <ProjectTabsContext.Provider value={{ selected, setSelected }}>
         <SuccessBanner param="created">{t("Project succesfully created!")}</SuccessBanner>
-        <EditBanner />
         <ProjectDetailNew />
       </ProjectTabsContext.Provider>
     </>

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { Checkbox, Stack, Tabs, Button } from "@bbtgnn/polaris-interfacer";
+import { Button, Checkbox, Stack, Tabs } from "@bbtgnn/polaris-interfacer";
 import { Cube, Events } from "@carbon/icons-react";
 import ProjectsCards from "components/ProjectsCards";
 // import ProjectsMaps from "components/ProjectsMaps";
@@ -22,10 +22,10 @@ import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
 import { ReactElement, useState } from "react";
 // import AgentsTable from "../components/AgentsTable";
+import dynamic from "next/dynamic";
 import SearchBar from "../components/SearchBar";
 import Layout from "../components/layout/SearchLayout";
 import useFilters from "../hooks/useFilters";
-import dynamic from "next/dynamic";
 import { NextPageWithLayout } from "./_app";
 
 const ProjectsMaps = dynamic(() => import("../components/ProjectsMaps"), { ssr: false });
@@ -46,11 +46,9 @@ const Search: NextPageWithLayout = () => {
     orName: q?.toString(),
     ...(!checkedNotDescription && { orNote: q?.toString() }),
   };
-  const projectsFilter = {
-    name: q?.toString(),
-    ...(!checkedNotDescription && { orNote: q?.toString() }),
-  };
-  const filters = isNotEmptyObj(proposalFilter) ? { ...proposalFilter, ...projectsFilter } : projectsOrFilter;
+  const filters = isNotEmptyObj(proposalFilter)
+    ? { ...proposalFilter, ...(!checkedNotDescription && { orNote: q?.toString() }) }
+    : projectsOrFilter;
 
   //
 


### PR DESCRIPTION
## Summary
- remove owner-only edit banners from profile and project detail pages while keeping inline edit actions
- fix search page filter composition to avoid sending mutually exclusive fields name and orName
- fix profile tab search by wiring search input into the projects query filter with debounce

## Commits
- refactor(ui): remove owner edit banners from profile and project detail pages
- fix(search): avoid sending both name and orName filter params
- fix(profile): wire search input to GraphQL filter in profile tabs

## Testing
- manual verification of search page error path and profile tab search behavior
