### PR TITLE
refactor(tags): ♻️ 🏷️ prefix user tags with tag- to disambiguate from system classifiedAs

### DIFF
--- a/.beads/last-touched
+++ b/.beads/last-touched
@@ -1,1 +1,1 @@
-interfacer-gui-vom.5
+interfacer-gui-i46

--- a/components/GeneralCard.tsx
+++ b/components/GeneralCard.tsx
@@ -7,6 +7,7 @@ import useWallet from "hooks/useWallet";
 import { IdeaPoints } from "lib/PointsDistribution";
 import findProjectImages from "lib/findProjectImages";
 import { isProjectType } from "lib/isProjectType";
+import { extractUserTagValues } from "lib/tagging";
 import { EconomicResource } from "lib/types";
 import { useTranslation } from "next-i18next";
 import Link from "next/link";
@@ -67,10 +68,11 @@ const GeneralCard = (props: GeneralCardProps) => {
 
 const Tags = () => {
   const { project } = useCardProject();
-  if (!project.classifiedAs?.length) return null;
+  const tags = extractUserTagValues(project.classifiedAs);
+  if (!tags.length) return null;
   return (
     <div className="p-3 border-t-1 border-t-gray-200">
-      <BrTags wrap={false} tags={project.classifiedAs || []} />
+      <BrTags wrap={false} tags={tags} />
     </div>
   );
 };

--- a/components/ProductsActiveFiltersBar.tsx
+++ b/components/ProductsActiveFiltersBar.tsx
@@ -18,7 +18,7 @@ import { useQuery } from "@apollo/client";
 import { Tag } from "@bbtgnn/polaris-interfacer";
 import { useResourceSpecs } from "hooks/useResourceSpecs";
 import { QUERY_MACHINES } from "lib/QueryAndMutation";
-import { isPrefixedTag, prefixedTag, REPAIRABILITY_AVAILABLE_TAG, TAG_PREFIX } from "lib/tagging";
+import { isSystemTag, prefixedTag, REPAIRABILITY_AVAILABLE_TAG, stripUserTagPrefix, TAG_PREFIX } from "lib/tagging";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
 
@@ -90,21 +90,10 @@ export default function ProductsActiveFiltersBar() {
 
   const categoryTags = rawTags.filter(tag => tag.startsWith(`${TAG_PREFIX.CATEGORY}-`));
 
-  const userTags = rawTags.filter(
-    tag =>
-      !isPrefixedTag(tag, [
-        TAG_PREFIX.MACHINE,
-        TAG_PREFIX.MATERIAL,
-        TAG_PREFIX.CATEGORY,
-        TAG_PREFIX.POWER_COMPAT,
-        TAG_PREFIX.POWER_REQ,
-        TAG_PREFIX.REPLICABILITY,
-        TAG_PREFIX.RECYCLABILITY,
-        TAG_PREFIX.REPAIRABILITY,
-        TAG_PREFIX.ENV_ENERGY,
-        TAG_PREFIX.ENV_CO2,
-      ])
-  );
+  // User-facing tags in the active filter bar: anything that isn't a known
+  // system-prefixed tag (includes both canonical `tag-*` entries and legacy
+  // un-prefixed values still present in older URLs).
+  const userTags = rawTags.filter(tag => !isSystemTag(tag));
 
   const derivedManufacturability = (() => {
     const fromParam = asCsvArray(router.query.manufacturability);
@@ -247,9 +236,9 @@ export default function ProductsActiveFiltersBar() {
   for (const tag of userTags) {
     const decoded = (() => {
       try {
-        return decodeURIComponent(tag);
+        return decodeURIComponent(stripUserTagPrefix(tag));
       } catch {
-        return tag;
+        return stripUserTagPrefix(tag);
       }
     })();
 

--- a/components/ProductsFilters.tsx
+++ b/components/ProductsFilters.tsx
@@ -21,13 +21,14 @@ import { MACHINE_TYPES } from "lib/resourceSpecs";
 import {
   CO2_THRESHOLDS_KG,
   ENERGY_THRESHOLDS_KWH,
-  isPrefixedTag,
+  extractUserTagValues,
   mergeTags,
+  normalizeUserTagsForSave,
   POWER_COMPATIBILITY_OPTIONS,
   POWER_REQUIREMENT_THRESHOLDS_W,
   prefixedTag,
-  RECYCLABILITY_THRESHOLDS_PCT,
   rangeFilterTags,
+  RECYCLABILITY_THRESHOLDS_PCT,
   REPAIRABILITY_AVAILABLE_TAG,
   REPLICABILITY_OPTIONS,
   TAG_PREFIX,
@@ -177,22 +178,9 @@ export default function ProductsFilters() {
     const query = router.query;
 
     const rawTags = query.tags ? (query.tags as string).split(",") : [];
-    // Keep derived tags out of the user tags selector.
-    const userTags = rawTags.filter(
-      tag =>
-        !isPrefixedTag(tag, [
-          TAG_PREFIX.MACHINE,
-          TAG_PREFIX.MATERIAL,
-          TAG_PREFIX.CATEGORY,
-          TAG_PREFIX.POWER_COMPAT,
-          TAG_PREFIX.POWER_REQ,
-          TAG_PREFIX.REPLICABILITY,
-          TAG_PREFIX.RECYCLABILITY,
-          TAG_PREFIX.REPAIRABILITY,
-          TAG_PREFIX.ENV_ENERGY,
-          TAG_PREFIX.ENV_CO2,
-        ])
-    );
+    // Show user-facing tag values (prefix stripped) in the tags selector so
+    // the chips read e.g. "laser cut" instead of "tag-laser-cut".
+    const userTags = extractUserTagValues(rawTags);
 
     const manufacturability = query.manufacturability
       ? (query.manufacturability as string).split(",")
@@ -295,8 +283,12 @@ export default function ProductsFilters() {
 
     const existingCategoryTags = rawTags.filter(tag => tag.startsWith(`${TAG_PREFIX.CATEGORY}-`));
 
+    // User-entered free-form tags get the canonical `tag-<slug>` prefix so they
+    // match how they are persisted on save.
+    const userTags = normalizeUserTagsForSave(filters.tags);
+
     const combinedTags = mergeTags(
-      filters.tags,
+      userTags,
       existingCategoryTags,
       machineTags,
       materialTags,

--- a/components/ProjectCardNew.tsx
+++ b/components/ProjectCardNew.tsx
@@ -9,6 +9,7 @@ import useWallet from "hooks/useWallet";
 import findProjectImages from "lib/findProjectImages";
 import { isProjectType } from "lib/isProjectType";
 import { IdeaPoints } from "lib/PointsDistribution";
+import { extractUserTagValues } from "lib/tagging";
 import { EconomicResource } from "lib/types";
 import { useTranslation } from "next-i18next";
 import Link from "next/link";
@@ -93,20 +94,8 @@ export default function ProjectCardNew({ project }: ProjectCardNewProps) {
   const hasStarred = project.id ? isLiked(project.id) : false;
   const displayCount = formatCount(erFollowerLength);
 
-  // Extract tags (filter out encoded machine/material tags)
-  const tags = (project.classifiedAs || [])
-    .filter(
-      tag =>
-        !tag.startsWith("machine-") &&
-        !tag.startsWith("material-") &&
-        !tag.startsWith("power_") &&
-        !tag.startsWith("replicability-") &&
-        !tag.startsWith("recyclability-") &&
-        !tag.startsWith("repairability") &&
-        !tag.startsWith("env_")
-    )
-    .map(tag => (tag.startsWith("category-") ? humanizeSlug(tag) : decodeURIComponent(tag)))
-    .slice(0, 4);
+  // Extract user-facing tags (strips `tag-` prefix and filters out system tags).
+  const tags = extractUserTagValues(project.classifiedAs).slice(0, 4);
 
   // Design-specific: requirements
   const machineTags = (project.classifiedAs || []).filter(tag => tag.startsWith("machine-")).map(humanizeSlug);

--- a/components/ProjectDetailNew.tsx
+++ b/components/ProjectDetailNew.tsx
@@ -20,6 +20,7 @@ import type { DppDocument } from "lib/dpp-types";
 import findProjectImages from "lib/findProjectImages";
 import { isProjectType } from "lib/isProjectType";
 import MdParser from "lib/MdParser";
+import { extractUserTagValues } from "lib/tagging";
 
 import { EconomicResource } from "lib/types";
 import { useTranslation } from "next-i18next";
@@ -1212,29 +1213,9 @@ export default function ProjectDetailNew() {
   const color = typeColors[projectType] || "var(--ifr-green)";
   const images = useMemo(() => findProjectImages(project), [project]);
 
-  // Internal tag prefixes to filter out
-  const internalPrefixes = [
-    "machine-",
-    "material-",
-    "category-",
-    "power_compat-",
-    "mat:",
-    "c:",
-    "pc:",
-    "env:",
-    "pwr:",
-    "rep:",
-    "m:",
-  ];
-
-  // Decode tags
-  const tags = useMemo(
-    () =>
-      (project.classifiedAs || [])
-        .filter((c: string) => !internalPrefixes.some(p => c.startsWith(p)))
-        .map((c: string) => decodeURIComponent(c)),
-    [project.classifiedAs]
-  );
+  // User-facing tags: filtered to `tag-*` entries (prefix stripped) with legacy
+  // un-prefixed values kept visible for backwards compatibility.
+  const tags = useMemo(() => extractUserTagValues(project.classifiedAs), [project.classifiedAs]);
 
   const machines = useMemo(
     () =>

--- a/components/ProjectsFilters.tsx
+++ b/components/ProjectsFilters.tsx
@@ -21,6 +21,7 @@ import { useState } from "react";
 // Select components
 import { Button, Card, Stack, Text } from "@bbtgnn/polaris-interfacer";
 import { getOptionValue } from "components/brickroom/utils/BrSelectUtils";
+import { extractUserTagValues, normalizeUserTagsForSave } from "lib/tagging";
 import SearchUsers from "./SearchUsers";
 import SelectProjectType from "./SelectProjectType";
 import SelectTags from "./SelectTags";
@@ -56,7 +57,10 @@ export default function ProjectsFilters(props: ProjectsFiltersProps) {
   // Converts query value in string array
   function getFilterValues(filter: ProjectFilter): Array<string> {
     if (!query[filter]) return [];
-    else return query[filter].split(",");
+    const values = query[filter].split(",");
+    // Present user tags to the user without the `tag-` prefix.
+    if (filter === "tags") return extractUserTagValues(values);
+    return values;
   }
 
   // Creating state and loading it them with existing values
@@ -72,7 +76,10 @@ export default function ProjectsFilters(props: ProjectsFiltersProps) {
 
   function applyFilters() {
     for (let f of ProjectFilters) {
-      if (queryFilters[f].length > 0) query[f] = queryFilters[f].join(",");
+      // User tags are prefixed when placed in the URL so they match the stored
+      // canonical `tag-<slug>` form.
+      const values = f === "tags" ? normalizeUserTagsForSave(queryFilters[f]) : queryFilters[f];
+      if (values.length > 0) query[f] = values.join(",");
       else delete query[f];
     }
 

--- a/components/ProjectsTableRow.tsx
+++ b/components/ProjectsTableRow.tsx
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import { extractUserTagValues } from "lib/tagging";
 import { EconomicResource } from "lib/types";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -74,7 +75,7 @@ const ProjectsTableRow = (props: { project: { node: EconomicResource } }) => {
       </td>
 
       <td className="max-w-[12rem]">
-        <BrTags tags={e.classifiedAs!} />
+        <BrTags tags={extractUserTagValues(e.classifiedAs)} />
       </td>
 
       <td>

--- a/hooks/useProjectCRUD.ts
+++ b/hooks/useProjectCRUD.ts
@@ -22,7 +22,7 @@ import {
 import { arrayEquals, getNewElements } from "lib/arrayOperations";
 import { errorFormatter } from "lib/errorFormatter";
 import { prepFilesForZenflows, uploadFiles } from "lib/fileUpload";
-import { derivedProductFilterTags, mergeTags, prefixedTag, removeTagsWithPrefixes, TAG_PREFIX } from "lib/tagging";
+import { derivedProductFilterTags, mergeTags, normalizeUserTagsForSave, prefixedTag, TAG_PREFIX } from "lib/tagging";
 import {
   CreateLocationMutation,
   CreateLocationMutationVariables,
@@ -224,7 +224,8 @@ export const useProjectCRUD = () => {
 
       const images: IFile[] = await prepFilesForZenflows(formData.images);
       devLog("info: images prepared", images);
-      const tags = formData.main.tags.length > 0 ? formData.main.tags : undefined;
+      const normalizedTags = normalizeUserTagsForSave(formData.main.tags);
+      const tags = normalizedTags.length > 0 ? normalizedTags : undefined;
       devLog("info: tags prepared", tags);
 
       const metadata = JSON.stringify({
@@ -354,19 +355,10 @@ export const useProjectCRUD = () => {
         .map(l => prefixedTag(TAG_PREFIX.LICENSE, l.licenseId))
         .filter((t): t is string => Boolean(t));
 
-      const baseTags = removeTagsWithPrefixes(formData.main.tags, [
-        TAG_PREFIX.CATEGORY,
-        TAG_PREFIX.POWER_COMPAT,
-        TAG_PREFIX.POWER_REQ,
-        TAG_PREFIX.REPLICABILITY,
-        TAG_PREFIX.RECYCLABILITY,
-        TAG_PREFIX.REPAIRABILITY,
-        TAG_PREFIX.ENV_ENERGY,
-        TAG_PREFIX.ENV_CO2,
-        TAG_PREFIX.SERVICE_TYPE,
-        TAG_PREFIX.AVAILABILITY,
-        TAG_PREFIX.LICENSE,
-      ]);
+      // User-entered free-form tags from the form are normalized into the
+      // canonical `tag-<slug>` shape. System-derived tags (machines, materials,
+      // categories, ...) are appended separately below.
+      const baseTags = normalizeUserTagsForSave(formData.main.tags);
 
       const merged = mergeTags(
         baseTags,

--- a/lib/tagging.ts
+++ b/lib/tagging.ts
@@ -11,6 +11,9 @@ export function slugifyTagValue(value: string): string {
 }
 
 export const TAG_PREFIX = {
+  // Dedicated prefix for free-form, user-entered tags. All other prefixes are
+  // system-derived metadata that happens to share the classifiedAs field.
+  USER: "tag",
   CATEGORY: "category",
   MACHINE: "machine",
   MATERIAL: "material",
@@ -27,6 +30,38 @@ export const TAG_PREFIX = {
 } as const;
 
 export type TagPrefix = (typeof TAG_PREFIX)[keyof typeof TAG_PREFIX];
+
+// All known system prefixes (everything except USER).
+export const SYSTEM_TAG_PREFIXES: ReadonlyArray<string> = [
+  TAG_PREFIX.CATEGORY,
+  TAG_PREFIX.MACHINE,
+  TAG_PREFIX.MATERIAL,
+  TAG_PREFIX.POWER_COMPAT,
+  TAG_PREFIX.POWER_REQ,
+  TAG_PREFIX.REPLICABILITY,
+  TAG_PREFIX.RECYCLABILITY,
+  TAG_PREFIX.REPAIRABILITY,
+  TAG_PREFIX.ENV_ENERGY,
+  TAG_PREFIX.ENV_CO2,
+  TAG_PREFIX.SERVICE_TYPE,
+  TAG_PREFIX.AVAILABILITY,
+  TAG_PREFIX.LICENSE,
+];
+
+// Legacy/stale system prefixes that still appear in historical classifiedAs data.
+// These must not leak into user-facing tag displays.
+export const LEGACY_SYSTEM_TAG_PATTERNS: ReadonlyArray<string> = [
+  "power_compat-",
+  "power_",
+  "env_",
+  "mat:",
+  "c:",
+  "pc:",
+  "env:",
+  "pwr:",
+  "rep:",
+  "m:",
+];
 
 // Shared option lists used across create flow + products filters.
 export const PRODUCT_CATEGORY_OPTIONS = [
@@ -198,4 +233,78 @@ export function mergeTags(...tagLists: Array<ReadonlyArray<string> | undefined>)
   }
 
   return merged;
+}
+
+// ---------- User tag helpers ----------
+//
+// User-entered free-form tags are stored in classifiedAs alongside system-derived
+// tags (machine-*, category-*, etc.). To disambiguate them we prefix every new
+// user tag with `tag-`. Display and filter code should go through these helpers
+// so there is a single source of truth and no drifting per-component blocklists.
+
+// Build a canonical user tag from raw input. Returns undefined for empty values.
+export function userTag(raw: string): string | undefined {
+  const slug = slugifyTagValue(raw);
+  if (!slug) return undefined;
+  return `${TAG_PREFIX.USER}-${slug}`;
+}
+
+export function isUserTag(tag: string): boolean {
+  return tag.startsWith(`${TAG_PREFIX.USER}-`);
+}
+
+export function stripUserTagPrefix(tag: string): string {
+  return isUserTag(tag) ? tag.substring(TAG_PREFIX.USER.length + 1) : tag;
+}
+
+// A tag is "system" if it uses one of the known system prefixes (current or
+// legacy). USER tags and legacy un-prefixed free-form tags are NOT system.
+export function isSystemTag(tag: string): boolean {
+  if (isUserTag(tag)) return false;
+  if (SYSTEM_TAG_PREFIXES.some(p => tag.startsWith(`${p}-`))) return true;
+  if (LEGACY_SYSTEM_TAG_PATTERNS.some(p => tag.startsWith(p))) return true;
+  return false;
+}
+
+// Extract the values a user should see as "tags" from a classifiedAs list:
+// - entries that match TAG_PREFIX.USER (stripped of the prefix)
+// - legacy un-prefixed free-form entries (kept visible for backwards compat)
+// System-prefixed entries are filtered out.
+export function extractUserTagValues(tags: ReadonlyArray<string> | null | undefined): string[] {
+  if (!tags || tags.length === 0) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const tag of tags) {
+    if (!tag) continue;
+    let value: string | undefined;
+    if (isUserTag(tag)) {
+      value = decodeURIComponent(stripUserTagPrefix(tag));
+    } else if (!isSystemTag(tag)) {
+      value = decodeURIComponent(tag);
+    }
+    if (!value) continue;
+    if (seen.has(value)) continue;
+    seen.add(value);
+    out.push(value);
+  }
+  return out;
+}
+
+// Normalize raw user tag inputs (free-form strings, optionally already prefixed)
+// into canonical `tag-<slug>` form. System-prefixed entries are dropped so they
+// cannot accidentally ride in via the user-tag pipeline.
+export function normalizeUserTagsForSave(tags: ReadonlyArray<string>): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of tags) {
+    const trimmed = raw?.trim();
+    if (!trimmed) continue;
+    if (isSystemTag(trimmed)) continue;
+    const canonical = isUserTag(trimmed) ? trimmed : userTag(trimmed);
+    if (!canonical) continue;
+    if (seen.has(canonical)) continue;
+    seen.add(canonical);
+    out.push(canonical);
+  }
+  return out;
 }

--- a/pages/resource/[id]/claim.tsx
+++ b/pages/resource/[id]/claim.tsx
@@ -35,6 +35,7 @@ import devLog from "lib/devLog";
 import { errorFormatter } from "lib/errorFormatter";
 import { formSetValueOptions } from "lib/formSetValueOptions";
 import { isRequired } from "lib/isFieldRequired";
+import { normalizeUserTagsForSave } from "lib/tagging";
 import { TransferProjectMutationVariables } from "lib/types";
 import { GetStaticPaths } from "next";
 import { useTranslation } from "next-i18next";
@@ -77,7 +78,7 @@ const ClaimProject: NextPageWithLayout = () => {
 
   async function handleClaim(formData: ClaimProjectNS.FormValues) {
     try {
-      const tags = formData.tags;
+      const tags = normalizeUserTagsForSave(formData.tags);
       devLog("info: tags prepared", tags);
       const contributors = formData.contributors;
       devLog("info: contributors prepared", contributors);


### PR DESCRIPTION
classifiedAs stores both user free-form tags and system-derived metadata (machine-*, material-*, category-*, powercompat-*, env-*, etc.), forcing display code to maintain drifting per-component blocklists to hide system tags from users.

Introduce a dedicated TAG_PREFIX.USER = "tag" prefix applied symmetrically on save and read:

- lib/tagging.ts: add userTag, isUserTag, stripUserTagPrefix, isSystemTag, extractUserTagValues, normalizeUserTagsForSave helpers plus SYSTEM_TAG_PREFIXES and LEGACY_SYSTEM_TAG_PATTERNS constants.
- Save sites (useProjectCRUD handleProjectCreation + handleMachineCreation, resource claim) normalize user-entered tags to tag-<slug>.
- URL filter producers (ProductsFilters, ProjectsFilters) prefix on apply and strip on load so chips show "laser cut" instead of "tag-laser-cut".
- Display sites (ProjectCardNew, ProjectDetailNew, GeneralCard, ProjectsTableRow, ProductsActiveFiltersBar) route through extractUserTagValues, removing bespoke blocklists (including stale mat:, c:, pc:, env:, pwr:, rep:, m: entries).
- Legacy un-prefixed tags remain visible via backwards-compat fallback in extractUserTagValues; no data migration required.

Closes interfacer-gui-i46.
