### PR TITLE
fix(docker): 🐛 replace broken pnpm download URL with corepack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,7 @@ ARG NODE_ENV=production
 ENV NODE_ENV=$NODE_ENV
 
 RUN apk add --no-cache libc6-compat
-RUN wget "https://github.com/pnpm/pnpm/releases/latest/download/pnpm-linuxstatic-x64" -O /bin/pnpm && \
-    chmod +x /bin/pnpm
+RUN corepack enable && corepack prepare pnpm@latest --activate
 
 WORKDIR /build
 


### PR DESCRIPTION
pnpm changed their release artifact naming, causing
https://github.com/pnpm/pnpm/releases/latest/download/pnpm-linuxstatic-x64
to return 404.

Use Node.js built-in corepack instead, which is the officially recommended
way to install pnpm in Docker images.
