### PR TITLE
fix: 🐛 restrict manufacturability filter to designs catalog, driven by derived products

### DIFF
--- a/components/CatalogFilterSidebar.tsx
+++ b/components/CatalogFilterSidebar.tsx
@@ -10,6 +10,7 @@ import ToggleSwitch from "components/ToggleSwitch";
 import { FetchLocation, fetchLocation, lookupLocation } from "lib/fetchLocation";
 import {
   AVAILABILITY_OPTIONS,
+  MANUFACTURABLE_TRUE_TAG,
   POWER_COMPATIBILITY_OPTIONS,
   PRODUCT_CATEGORY_OPTIONS,
   REPAIRABILITY_AVAILABLE_TAG,
@@ -85,7 +86,6 @@ const LICENSES = [
 export default function CatalogFilterSidebar({ variant, collapsed = false, onToggle }: CatalogFilterSidebarProps) {
   const { t } = useTranslation("common");
   const router = useRouter();
-  const [manufacturingFilter, setManufacturingFilter] = useState("all");
 
   // --- Geo location state ---
   const urlRadius = router.query.nearDistanceKm ? Number(router.query.nearDistanceKm) : 50;
@@ -345,40 +345,60 @@ export default function CatalogFilterSidebar({ variant, collapsed = false, onTog
               icon={<Tools size={16} />}
               label="Manufacturability"
               defaultOpen
-              badge={manufacturingFilter !== "all" ? 1 : undefined}
+              badge={currentTags.includes(MANUFACTURABLE_TRUE_TAG) ? 1 : undefined}
             >
               <div className="flex flex-col gap-2.5">
                 {[
                   { value: "all", label: "All" },
                   { value: "can_be_manufactured", label: "Can be manufactured" },
-                  { value: "in_progress", label: "In progress" },
-                ].map(option => (
-                  <div
-                    key={option.value}
-                    className="flex items-center gap-2 cursor-pointer"
-                    onClick={() => setManufacturingFilter(option.value)}
-                  >
+                ].map(option => {
+                  const isSelected =
+                    option.value === "all"
+                      ? !currentTags.includes(MANUFACTURABLE_TRUE_TAG)
+                      : currentTags.includes(MANUFACTURABLE_TRUE_TAG);
+
+                  return (
                     <div
-                      className="w-4 h-4 border shrink-0 flex items-center justify-center transition-colors"
-                      style={{
-                        borderRadius: "50%",
-                        backgroundColor:
-                          manufacturingFilter === option.value ? "var(--ifr-green)" : "var(--ifr-bg-surface)",
-                        borderColor: manufacturingFilter === option.value ? "var(--ifr-green)" : "var(--ifr-border)",
+                      key={option.value}
+                      className="flex items-center gap-2 cursor-pointer"
+                      onClick={() => {
+                        if (isSelected) return;
+
+                        let newTags: string[];
+                        if (option.value === "all") {
+                          newTags = currentTags.filter(t => t !== MANUFACTURABLE_TRUE_TAG);
+                        } else {
+                          newTags = [...currentTags, MANUFACTURABLE_TRUE_TAG];
+                        }
+
+                        const query = { ...router.query };
+                        if (newTags.length > 0) {
+                          query.tags = newTags.join(",");
+                        } else {
+                          delete query.tags;
+                        }
+                        router.push({ pathname: router.pathname, query }, undefined, { shallow: true });
                       }}
                     >
-                      {manufacturingFilter === option.value && (
-                        <div className="w-1.5 h-1.5 bg-white" style={{ borderRadius: "50%" }} />
-                      )}
+                      <div
+                        className="w-4 h-4 border shrink-0 flex items-center justify-center transition-colors"
+                        style={{
+                          borderRadius: "50%",
+                          backgroundColor: isSelected ? "var(--ifr-green)" : "var(--ifr-bg-surface)",
+                          borderColor: isSelected ? "var(--ifr-green)" : "var(--ifr-border)",
+                        }}
+                      >
+                        {isSelected && <div className="w-1.5 h-1.5 bg-white" style={{ borderRadius: "50%" }} />}
+                      </div>
+                      <span
+                        className="text-ifr-text-primary"
+                        style={{ fontFamily: "var(--ifr-font-body)", fontSize: "var(--ifr-fs-base)" }}
+                      >
+                        {t(option.label)}
+                      </span>
                     </div>
-                    <span
-                      className="text-ifr-text-primary"
-                      style={{ fontFamily: "var(--ifr-font-body)", fontSize: "var(--ifr-fs-base)" }}
-                    >
-                      {t(option.label)}
-                    </span>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             </FilterSection>
           </>
@@ -440,42 +460,6 @@ export default function CatalogFilterSidebar({ variant, collapsed = false, onTog
                   router.push({ pathname: router.pathname, query }, undefined, { shallow: true });
                 }}
               />
-            </FilterSection>
-
-            <FilterSection icon={<Tools size={16} />} label="Manufacturability">
-              <div className="flex flex-col gap-2.5">
-                {[
-                  { value: "all", label: "All" },
-                  { value: "can_be_manufactured", label: "Can be manufactured" },
-                  { value: "in_progress", label: "In progress" },
-                ].map(option => (
-                  <div
-                    key={option.value}
-                    className="flex items-center gap-2 cursor-pointer"
-                    onClick={() => setManufacturingFilter(option.value)}
-                  >
-                    <div
-                      className="w-4 h-4 border shrink-0 flex items-center justify-center transition-colors"
-                      style={{
-                        borderRadius: "50%",
-                        backgroundColor:
-                          manufacturingFilter === option.value ? "var(--ifr-green)" : "var(--ifr-bg-surface)",
-                        borderColor: manufacturingFilter === option.value ? "var(--ifr-green)" : "var(--ifr-border)",
-                      }}
-                    >
-                      {manufacturingFilter === option.value && (
-                        <div className="w-1.5 h-1.5 bg-white" style={{ borderRadius: "50%" }} />
-                      )}
-                    </div>
-                    <span
-                      className="text-ifr-text-primary"
-                      style={{ fontFamily: "var(--ifr-font-body)", fontSize: "var(--ifr-fs-base)" }}
-                    >
-                      {t(option.label)}
-                    </span>
-                  </div>
-                ))}
-              </div>
             </FilterSection>
           </>
         )}

--- a/components/ProductsActiveFiltersBar.tsx
+++ b/components/ProductsActiveFiltersBar.tsx
@@ -95,16 +95,6 @@ export default function ProductsActiveFiltersBar() {
   // un-prefixed values still present in older URLs).
   const userTags = rawTags.filter(tag => !isSystemTag(tag));
 
-  const derivedManufacturability = (() => {
-    const fromParam = asCsvArray(router.query.manufacturability);
-    if (fromParam.length > 0) return fromParam[0];
-
-    const show = asString(router.query.show);
-    if (show === "designs") return "in-progress";
-    if (show === "products") return "can-manufacture";
-    return "";
-  })();
-
   const show = asString(router.query.show);
 
   const powerMin = asString(router.query.powerMin);
@@ -121,7 +111,6 @@ export default function ProductsActiveFiltersBar() {
     categoryTags.length > 0 ||
     machines.length > 0 ||
     materials.length > 0 ||
-    Boolean(derivedManufacturability) ||
     (show.length > 0 && show !== "all") ||
     asCsvArray(router.query.power).length > 0 ||
     Boolean(powerMin) ||
@@ -179,26 +168,7 @@ export default function ProductsActiveFiltersBar() {
     });
   }
 
-  if (derivedManufacturability) {
-    const label =
-      derivedManufacturability === "in-progress"
-        ? t("In Progress")
-        : derivedManufacturability === "can-manufacture"
-        ? t("Can be Manufactured")
-        : derivedManufacturability;
-
-    chips.push({
-      key: `manufacturability:${derivedManufacturability}`,
-      label: `${t("Manufacturability")}: ${label}`,
-      onRemove: () => {
-        const next = { ...router.query };
-        delete next.manufacturability;
-        // Manufacturability is represented by `show` (designs/products).
-        delete next.show;
-        pushQuery(next);
-      },
-    });
-  } else if (show && show !== "all") {
+  if (show && show !== "all") {
     const showLabel = show === "services" ? t("Services") : show;
     chips.push({
       key: `show:${show}`,

--- a/components/ProductsFilters.tsx
+++ b/components/ProductsFilters.tsx
@@ -57,7 +57,6 @@ interface MachinesQueryData {
 }
 
 export interface ProductsFiltersState {
-  manufacturability: string[];
   machinesNeeded: string[]; // Now stores machine IDs instead of names
   materialsNeeded: string[];
   location: string;
@@ -89,12 +88,6 @@ const FALLBACK_MACHINES_OPTIONS = [
 ];
 
 const MATERIALS_OPTIONS = ["PLA", "ABS", "PETG", "Aluminum", "Steel", "Wood", "Acrylic", "Carbon Fiber", "Plywood"];
-
-const MANUFACTURABILITY_OPTIONS = [
-  { value: "all", label: "All" },
-  { value: "can-manufacture", label: "Can be Manufactured" },
-  { value: "in-progress", label: "In Progress" },
-];
 
 // Option lists are exported from lib/tagging to keep create flow + filters consistent.
 
@@ -140,7 +133,6 @@ export default function ProductsFilters() {
 
   // Collapsible sections state
   const [openSections, setOpenSections] = useState({
-    manufacturability: true,
     machines: false,
     materials: false,
     location: false,
@@ -155,7 +147,6 @@ export default function ProductsFilters() {
 
   // Filter state
   const [filters, setFilters] = useState<ProductsFiltersState>({
-    manufacturability: [],
     machinesNeeded: [],
     materialsNeeded: [],
     location: "",
@@ -182,17 +173,7 @@ export default function ProductsFilters() {
     // the chips read e.g. "laser cut" instead of "tag-laser-cut".
     const userTags = extractUserTagValues(rawTags);
 
-    const manufacturability = query.manufacturability
-      ? (query.manufacturability as string).split(",")
-      : (() => {
-          const show = (query.show as string) || "";
-          if (show === "designs") return ["in-progress"];
-          if (show === "products") return ["can-manufacture"];
-          return [];
-        })();
-
     setFilters({
-      manufacturability,
       machinesNeeded: query.machines ? (query.machines as string).split(",") : [],
       materialsNeeded: query.materials ? (query.materials as string).split(",") : [],
       location: (query.location as string) || "",
@@ -301,14 +282,6 @@ export default function ProductsFilters() {
       co2Tags
     );
 
-    if (filters.manufacturability.length > 0) query.manufacturability = filters.manufacturability.join(",");
-
-    // Manufacturability is implemented as a spec/type filter (conformsTo) via the existing `show` param.
-    const manufacturabilityValue = filters.manufacturability[0];
-    if (manufacturabilityValue === "in-progress") query.show = "designs";
-    if (manufacturabilityValue === "can-manufacture") query.show = "products";
-    if (manufacturabilityValue === "all") delete query.show;
-
     if (filters.machinesNeeded.length > 0) query.machines = filters.machinesNeeded.join(",");
     if (filters.materialsNeeded.length > 0) query.materials = filters.materialsNeeded.join(",");
     if (filters.location) query.location = filters.location;
@@ -330,7 +303,6 @@ export default function ProductsFilters() {
 
   const resetFilters = () => {
     setFilters({
-      manufacturability: [],
       machinesNeeded: [],
       materialsNeeded: [],
       location: "",
@@ -366,53 +338,6 @@ export default function ProductsFilters() {
           <span className="text-xs font-medium text-white bg-[#036A53] px-2 py-1 rounded-full">
             {activeFilterCount}
           </span>
-        )}
-      </div>
-
-      {/* Manufacturability */}
-      <div className="border-b border-[#C9CCCF] pb-4">
-        <button
-          onClick={() => toggleSection("manufacturability")}
-          className="flex items-center justify-between w-full text-left"
-        >
-          <span className="font-medium text-gray-900" style={{ fontFamily: "'IBM Plex Sans', sans-serif" }}>
-            {t("Manufacturability")}
-          </span>
-          <svg
-            className={`w-5 h-5 text-gray-500 transition-transform ${
-              openSections.manufacturability ? "rotate-180" : ""
-            }`}
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-          </svg>
-        </button>
-        {openSections.manufacturability && (
-          <div className="mt-3 space-y-2">
-            {MANUFACTURABILITY_OPTIONS.map(option => (
-              <div key={option.value} className="flex items-center">
-                <input
-                  type="radio"
-                  id={`manuf-${option.value}`}
-                  name="manufacturability"
-                  value={option.value}
-                  checked={filters.manufacturability.includes(option.value)}
-                  onChange={e => {
-                    setFilters(prev => ({
-                      ...prev,
-                      manufacturability: e.target.checked ? [option.value] : [],
-                    }));
-                  }}
-                  className="w-4 h-4 text-[#036A53] focus:ring-[#036A53]"
-                />
-                <label htmlFor={`manuf-${option.value}`} className="ml-2 text-sm text-gray-700">
-                  {t(option.label)}
-                </label>
-              </div>
-            ))}
-          </div>
         )}
       </div>
 

--- a/hooks/useProjectCRUD.ts
+++ b/hooks/useProjectCRUD.ts
@@ -18,19 +18,29 @@ import {
   QUERY_UNIT_AND_CURRENCY,
   RELOCATE_PROJECT,
   UPDATE_METADATA,
+  UPDATE_RESOURCE_CLASSIFIED_AS,
 } from "lib/QueryAndMutation";
 import { arrayEquals, getNewElements } from "lib/arrayOperations";
 import useDppApi from "lib/dpp";
 import { errorFormatter } from "lib/errorFormatter";
 import { prepFilesForZenflows, uploadFiles } from "lib/fileUpload";
 import { uploadModelFilesToDpp } from "lib/projectModelFiles";
-import { derivedProductFilterTags, mergeTags, normalizeUserTagsForSave, prefixedTag, TAG_PREFIX } from "lib/tagging";
+import {
+  derivedProductFilterTags,
+  MANUFACTURABLE_TRUE_TAG,
+  mergeTags,
+  normalizeUserTagsForSave,
+  prefixedTag,
+  TAG_PREFIX,
+} from "lib/tagging";
 import {
   CreateLocationMutation,
   CreateLocationMutationVariables,
   CreateProjectMutation,
   CreateProjectMutationVariables,
   EconomicResource,
+  EditMainMutation,
+  EditMainMutationVariables,
   GetUnitAndCurrencyQuery,
   IFile,
 } from "lib/types";
@@ -68,6 +78,9 @@ export const useProjectCRUD = () => {
   const [createMachineResource] = useMutation(CREATE_MACHINE_RESOURCE);
   const [createLocation] = useMutation<CreateLocationMutation, CreateLocationMutationVariables>(CREATE_LOCATION);
   const [createProcessMutation] = useMutation(CREATE_PROCESS);
+  const [updateResourceClassifiedAs] = useMutation<EditMainMutation, EditMainMutationVariables>(
+    UPDATE_RESOURCE_CLASSIFIED_AS
+  );
   const { refetch } = useQuery(ASK_RESOURCE_PRIMARY_ACCOUNTABLE);
 
   type SpatialThingRes = CreateLocationMutation["createSpatialThing"]["spatialThing"];
@@ -514,15 +527,19 @@ export const useProjectCRUD = () => {
           process: processId,
           originalProjectId: projectId,
         });
-        /*
-        const project = await getProjectForMetadataUpdate(linkedDesign);
-        if (project.metadata?.relations) {
-          const relations: string[] = [...project.metadata.relations, projectId];
-          await updateRelations(linkedDesign, relations, true);
-        } else {
-          await updateRelations(linkedDesign, [projectId], true);
+
+        // Mark the parent design as manufacturable by adding the tag.
+        try {
+          const design = await getProjectForMetadataUpdate(linkedDesign);
+          const currentTags = (design.classifiedAs || []).filter((t: string) => t !== MANUFACTURABLE_TRUE_TAG);
+          const updatedTags = [...currentTags, MANUFACTURABLE_TRUE_TAG];
+          await updateResourceClassifiedAs({
+            variables: { id: linkedDesign, classifiedAs: updatedTags },
+          });
+          devLog("success: design marked as manufacturable", linkedDesign);
+        } catch (e) {
+          devLog("error: failed to mark design as manufacturable", e);
         }
-        */
       }
 
       for (const resource of formData.relations) {

--- a/lib/QueryAndMutation.ts
+++ b/lib/QueryAndMutation.ts
@@ -1200,6 +1200,16 @@ export const UPDATE_METADATA = gql`
   }
 `;
 
+export const UPDATE_RESOURCE_CLASSIFIED_AS = gql`
+  mutation updateResourceClassifiedAs($id: ID!, $classifiedAs: [URI!]) {
+    updateEconomicResource(resource: { id: $id, classifiedAs: $classifiedAs }) {
+      economicResource {
+        id
+      }
+    }
+  }
+`;
+
 export const UPDATE_CONTRIBUTION = gql`
   mutation updateContribution(
     $process: ID!
@@ -1234,6 +1244,7 @@ export const QUERY_PROJECT_FOR_METADATA_UPDATE = gql`
     economicResource(id: $id) {
       id
       name
+      classifiedAs
       metadata
       onhandQuantity {
         hasUnit {

--- a/lib/tagging.ts
+++ b/lib/tagging.ts
@@ -27,6 +27,7 @@ export const TAG_PREFIX = {
   SERVICE_TYPE: "servicetype",
   AVAILABILITY: "availability",
   LICENSE: "license",
+  MANUFACTURABLE: "manufacturable",
 } as const;
 
 export type TagPrefix = (typeof TAG_PREFIX)[keyof typeof TAG_PREFIX];
@@ -46,6 +47,7 @@ export const SYSTEM_TAG_PREFIXES: ReadonlyArray<string> = [
   TAG_PREFIX.SERVICE_TYPE,
   TAG_PREFIX.AVAILABILITY,
   TAG_PREFIX.LICENSE,
+  TAG_PREFIX.MANUFACTURABLE,
 ];
 
 // Legacy/stale system prefixes that still appear in historical classifiedAs data.
@@ -102,6 +104,9 @@ export const RECYCLABILITY_THRESHOLDS_PCT = [0, 10, 20, 30, 40, 50, 60, 70, 80, 
 
 // Repairability is a simple binary tag: either the product is repairable or not.
 export const REPAIRABILITY_AVAILABLE_TAG = "repairability-available";
+
+// Manufacturability tags – added to designs when a product is derived from them.
+export const MANUFACTURABLE_TRUE_TAG = "manufacturable-true";
 
 // Numeric thresholds used for monotonic range tags.
 // Keep these lists stable: changing them will change the derived tags.

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -4671,6 +4671,7 @@ export type QueryProjectForMetadataUpdateQuery = {
     __typename?: "EconomicResource";
     id: string;
     name: string;
+    classifiedAs?: Array<string> | null;
     metadata?: any | null;
     onhandQuantity: {
       __typename?: "Measure";


### PR DESCRIPTION
- Remove manufacturability filter from products catalog sidebar
- Make designs manufacturability filter functional via classifiedAs tag
- Set manufacturable-true tag on design via updateEconomicResource when a product derives from it
- Clean up dead manufacturability code from old ProductsFilters/ActiveFiltersBar

close: #856 
