### PR TITLE
fix(cards): 🐛 remove image rounded corners and allow two-line titles

### DIFF
--- a/.beads/last-touched
+++ b/.beads/last-touched
@@ -1,1 +1,1 @@
-interfacer-gui-4c2.3
+interfacer-gui-1tv

--- a/components/ProjectCardImage.tsx
+++ b/components/ProjectCardImage.tsx
@@ -34,7 +34,7 @@ const ProjectImage = (props: Props) => {
   };
 
   return (
-    <div className="h-60 bg-base-200 rounded-lg flex items-center justify-center overflow-hidden">
+    <div className="h-60 bg-base-200 flex items-center justify-center overflow-hidden">
       {(!image || error) && (
         <div className="opacity-40">
           <ProjectTypeRoundIcon projectType={projectType} />

--- a/components/ProjectCardNew.tsx
+++ b/components/ProjectCardNew.tsx
@@ -228,11 +228,15 @@ export default function ProjectCardNew({ project }: ProjectCardNewProps) {
             {/* Title + Description */}
             <div className="flex flex-col gap-1">
               <h3
-                className="text-ifr-text-primary leading-[30px] truncate"
+                className="text-ifr-text-primary leading-[30px]"
                 style={{
                   fontFamily: "var(--ifr-font-heading)",
                   fontSize: "var(--ifr-fs-lg)",
                   fontWeight: "var(--ifr-fw-bold)",
+                  display: "-webkit-box",
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: "vertical",
+                  overflow: "hidden",
                 }}
               >
                 {project.name}


### PR DESCRIPTION
- Remove rounded-lg from ProjectCardImage to avoid conflicting with card border radius
- Change title from single-line truncate to two-line clamp for better readability of long names

close: #855 