### PR TITLE
fix(docker): 🐛 pin pnpm version to fix frozen-lockfile mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ARG NODE_ENV=production
 ENV NODE_ENV=$NODE_ENV
 
 RUN apk add --no-cache libc6-compat
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable
 
 WORKDIR /build
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "interfacer-gui",
   "version": "0.1.1",
   "private": true,
+  "packageManager": "pnpm@9.13.1",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Problem

The Docker publish workflow fails at `pnpm install --frozen-lockfile` with `ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE`.

**Root cause:** The Dockerfile uses `corepack prepare pnpm@latest --activate`, which installs pnpm 11.x. The `pnpm-lock.yaml` was generated with pnpm 9.x (lockfileVersion `9.0`). pnpm 11 cannot process this lockfile with `--frozen-lockfile`.

## Fix

1. **Added `packageManager` field** to `package.json` specifying `pnpm@9.13.1` — this is the standard way to declare the package manager version
2. **Simplified Dockerfile** — removed explicit `pnpm@latest`, letting corepack auto-detect the version from `package.json`

Now when `pnpm` is called inside the Docker build, corepack reads `packageManager` and downloads the exact matching version (9.13.1).