### PR TITLE
fix: 🐛 use publicRuntimeConfig for API URLs instead of NEXT_PUBLIC_*

### DIFF
--- a/components/partials/project/[id]/GC1DPP.tsx
+++ b/components/partials/project/[id]/GC1DPP.tsx
@@ -2,6 +2,7 @@ import { Collapsible, Spinner, Text } from "@bbtgnn/polaris-interfacer";
 import { ChevronDownMinor, ChevronUpMinor } from "@shopify/polaris-icons";
 import { useTranslation } from "next-i18next";
 import React, { useCallback, useEffect, useState } from "react";
+import { getRuntimeConfig } from "../../../../lib/runtimeConfig";
 
 interface DPPValue {
   type: string;
@@ -223,7 +224,8 @@ const GC1DPP: React.FC<GC1DPPProps> = ({ ulid }) => {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const response = await fetch(`${process.env.NEXT_PUBLIC_DPP_URL}/dpp/${ulid}`);
+        const { dppUrl } = getRuntimeConfig();
+        const response = await fetch(`${dppUrl}/dpp/${ulid}`);
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }

--- a/lib/createApolloClient.ts
+++ b/lib/createApolloClient.ts
@@ -19,6 +19,7 @@ import useStorage from "../hooks/useStorage";
 import sign from "zenflows-crypto/src/sign_graphql.zen";
 
 import { ApolloClient, HttpLink, InMemoryCache } from "@apollo/client";
+import { getRuntimeConfig } from "./runtimeConfig";
 
 interface FetchHttpOptions {
   uri?: string;
@@ -45,8 +46,9 @@ const useAuthAndFetch = async (uri: RequestInfo, options: RequestInit) => {
 };
 
 const createApolloClient = (withSignedCalls = false) => {
+  const { zenflowsUrl } = getRuntimeConfig();
   var opts: FetchHttpOptions = {
-    uri: process.env.NEXT_PUBLIC_ZENFLOWS_URL,
+    uri: zenflowsUrl,
   };
   if (withSignedCalls) {
     opts.fetch = useAuthAndFetch;

--- a/lib/dpp.ts
+++ b/lib/dpp.ts
@@ -13,6 +13,7 @@ import { useAuth } from "hooks/useAuth";
 import { useCallback, useMemo } from "react";
 // @ts-ignore
 import sign from "zenflows-crypto/src/sign_graphql.zen";
+import { getRuntimeConfig } from "./runtimeConfig";
 import type {
   Attachment,
   CreateDppResponse,
@@ -25,7 +26,7 @@ import type {
   UpdateDppResponse,
 } from "./dpp-types";
 
-const DPP_BASE_URL = process.env.NEXT_PUBLIC_DPP_URL;
+const { dppUrl: DPP_BASE_URL } = getRuntimeConfig();
 
 class DppRequestError extends Error {
   status: number;

--- a/lib/fileUpload.ts
+++ b/lib/fileUpload.ts
@@ -21,6 +21,7 @@ import { IFile } from "lib/types";
 import sign from "zenflows-crypto/src/sign_graphql.zen";
 import { zencode_exec, zenroom_hash_final, zenroom_hash_init, zenroom_hash_update } from "zenroom";
 import devLog from "./devLog";
+import { getRuntimeConfig } from "./runtimeConfig";
 //
 
 export function formatZenObjects(o: Record<string, unknown>): string {
@@ -105,7 +106,8 @@ export async function uploadFile(file: File) {
     const filesArray = new FormData();
     filesArray.append(hash, file);
 
-    await fetch(process.env.NEXT_PUBLIC_ZENFLOWS_FILE_URL!, {
+    const { zenflowsFileUrl } = getRuntimeConfig();
+    await fetch(zenflowsFileUrl, {
       method: "POST",
       body: filesArray,
     });
@@ -162,7 +164,8 @@ export async function UploadFileOnDPP(file: File): Promise<AttachmentResponse> {
   const signature = await SignMessage(checksum);
   const formData = new FormData();
   formData.append("file", file);
-  const response = await fetch(`${process.env.NEXT_PUBLIC_DPP_URL}/upload`, {
+  const { dppUrl } = getRuntimeConfig();
+  const response = await fetch(`${dppUrl}/upload`, {
     method: "POST",
     headers: {
       "did-pk": eddsaPublicKey!,

--- a/lib/findProjectModels.ts
+++ b/lib/findProjectModels.ts
@@ -1,3 +1,4 @@
+import { getRuntimeConfig } from "./runtimeConfig";
 import { EconomicResource } from "./types";
 
 type RawModelEntry =
@@ -32,7 +33,7 @@ export type ProjectModelDescriptor = {
 };
 
 const supportedExtensions = new Set(["step", "stp", "stl"]);
-const DPP_BASE_URL = process.env.NEXT_PUBLIC_DPP_URL;
+const { dppUrl: DPP_BASE_URL } = getRuntimeConfig();
 
 function isResolvableUrl(value: string): boolean {
   if (!value) {

--- a/lib/projectModelFiles.ts
+++ b/lib/projectModelFiles.ts
@@ -1,4 +1,5 @@
 import type { Attachment } from "./dpp-types";
+import { getRuntimeConfig } from "./runtimeConfig";
 
 export type ProjectModelMetadata = {
   contentType?: string;
@@ -16,7 +17,7 @@ export type ProjectModelMetadata = {
 };
 
 type UploadModelFile = (file: File) => Promise<Attachment>;
-const DPP_BASE_URL = process.env.NEXT_PUBLIC_DPP_URL;
+const { dppUrl: DPP_BASE_URL } = getRuntimeConfig();
 
 function getExtension(fileName: string): string {
   return fileName.split(".").pop()?.toLowerCase() || "";

--- a/lib/runtimeConfig.ts
+++ b/lib/runtimeConfig.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2022-2023 Dyne.org foundation <foundation@dyne.org>.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Runtime configuration accessor.
+ *
+ * These values are evaluated at request time (not build time),
+ * allowing them to be set via container environment variables
+ * even when NEXT_PUBLIC_* were not available during docker build.
+ */
+import getConfig from "next/config";
+
+export function getRuntimeConfig() {
+  const { publicRuntimeConfig } = getConfig() as {
+    publicRuntimeConfig: { zenflowsUrl: string; zenflowsFileUrl: string; dppUrl: string };
+  };
+  return publicRuntimeConfig;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -24,6 +24,11 @@ const nextConfig = {
   reactStrictMode: true,
   swcMinify: true,
   output: "standalone",
+  publicRuntimeConfig: {
+    zenflowsUrl: process.env.NEXT_PUBLIC_ZENFLOWS_URL || "",
+    zenflowsFileUrl: process.env.NEXT_PUBLIC_ZENFLOWS_FILE_URL || "",
+    dppUrl: process.env.NEXT_PUBLIC_DPP_URL || "",
+  },
   experimental: {
     transpilePackages: ["react-markdown-editor-lite"],
   },


### PR DESCRIPTION
## Problem

After deploying the previous Docker build fix, the GUI shows GraphQL queries going to `https://dpp-dev.ddns.dyne.org/graphql` instead of the correct proxy endpoint.

**Root cause**: `NEXT_PUBLIC_*` env vars are **inlined at Docker build time** into the JS bundle. During CI builds on GitHub Actions, no `.env` files exist (they're gitignored), so these variables are `undefined`. Apollo Client's `HttpLink` defaults to `/graphql` when `uri` is `undefined`.

Even though `gui.env` sets these at container runtime via docker-compose, it's too late — the client bundle already has `undefined` baked in.

## Fix

Replaced all `process.env.NEXT_PUBLIC_ZENFLOWS_URL`, `NEXT_PUBLIC_DPP_URL`, and `NEXT_PUBLIC_ZENFLOWS_FILE_URL` with **`publicRuntimeConfig`** from `next/config`, which is evaluated at **request time** (when the container runs with correct env vars from docker-compose).

### Changes

- **`next.config.js`** — Added `publicRuntimeConfig` with `zenflowsUrl`, `zenflowsFileUrl`, `dppUrl`
- **`lib/runtimeConfig.ts`** — New shared accessor using `next/config`
- **`lib/createApolloClient.ts`** — Use runtime `zenflowsUrl` instead of `NEXT_PUBLIC_ZENFLOWS_URL`
- **`lib/dpp.ts`** — Use runtime `dppUrl`
- **`lib/findProjectModels.ts`** — Use runtime `dppUrl`
- **`lib/fileUpload.ts`** — Use runtime `zenflowsFileUrl` + `dppUrl`
- **`lib/projectModelFiles.ts`** — Use runtime `dppUrl`
- **`components/…/GC1DPP.tsx`** — Use runtime `dppUrl`

### OPS repo companion fix

`gui.env.j2`: Replace `${BASE_URL}/...` (shell syntax, not expanded by Docker env_file) with `https://{{ proxy_domain_name }}/...` (proper Jinja2 variables).

## Verification

Docker build tested locally and succeeds.