### PR TITLE
fix(docker): 🐛 simplify Dockerfile — build at startup so gui.env vars are available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,53 +17,27 @@
 
 # TODO: move config to runtime https://github.com/vercel/next.js/discussions/17641
 
-FROM node:lts-alpine AS builder
+FROM node:lts-alpine
 
 RUN apk add --no-cache libc6-compat
 RUN corepack enable
 
 WORKDIR /build
 
-# Install ALL dependencies first (NODE_ENV is not set yet, so devDeps are included)
+# Install dependencies first (NODE_ENV is not set yet, so devDeps are included)
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
 # Copy source
 COPY . .
 
-# Set NODE_ENV only for the build step (Next.js reads it for optimizations)
+# Set NODE_ENV only after deps install (Next.js reads it at build time for optimizations)
 ARG HOST=0.0.0.0
 ENV HOST=$HOST
 ARG PORT=3000
 ENV PORT=$PORT
 ENV NODE_ENV=production
-
-RUN pnpm build
-
-# ----
-FROM node:lts-alpine AS runner
-
-RUN apk add --no-cache libc6-compat
-RUN corepack enable
-
-WORKDIR /app
-
-ENV NODE_ENV=production
-ARG HOST=0.0.0.0
-ENV HOST=$HOST
-ARG PORT=3000
-ENV PORT=$PORT
-
-# Fresh install of production-only dependencies
-COPY --from=builder /build/package.json /build/pnpm-lock.yaml ./
-RUN pnpm install --frozen-lockfile --prod
-
-# Copy build output and runtime configs
-COPY --from=builder /build/.next ./.next
-COPY --from=builder /build/public ./public
-COPY --from=builder /build/next.config.js ./
-COPY --from=builder /build/next-i18next.config.js ./
 
 EXPOSE $PORT
 
-CMD ["pnpm", "start"]
+CMD pnpm build && pnpm start


### PR DESCRIPTION
## Problem

PR #865 moved `next build` to Docker image build time (multi-stage). On CI, no `.env` files exist (gitignored), so `NEXT_PUBLIC_*` vars were `undefined` when inlined into the client JS bundle. Apollo defaulted to `/graphql`.

## Fix

Reverts to a **single stage** Dockerfile that:
- Installs deps **before** setting `NODE_ENV=production` (devDeps like TypeScript are included)
- Runs `pnpm build` at **container startup** via `CMD`, when `gui.env` is already loaded by docker-compose
- Keeps `NODE_ENV=production` for Next.js build optimizations

This restores the original deployment pattern where `NEXT_PUBLIC_*` vars are available during `next build` because docker-compose has already loaded `gui.env`.

### Companion PR

[DTECH_HSU_2025_OPS#7](https://github.com/interfacerproject/DTECH_HSU_2025_OPS/pull/7) — fixes `gui.env.j2` to use proper Jinja2 variables instead of `${BASE_URL}`