### PR TITLE
feat: ✨ replace CAD file upload with URL-based model links

### DIFF
--- a/components/StepModelViewer.tsx
+++ b/components/StepModelViewer.tsx
@@ -210,6 +210,7 @@ const StepModelViewer = ({
 
   return (
     <div ref={viewerRootRef} style={{ position: "relative" }}>
+      {/* File header: name + download link */}
       {(fileName || downloadUrl) && (
         <div
           style={{
@@ -234,46 +235,65 @@ const StepModelViewer = ({
         </div>
       )}
 
+      {/* Error state — no viewer, just a well-formatted error card */}
       {error ? (
         <div
-          style={{ display: "flex", gap: "0.75rem", alignItems: "center", flexWrap: "wrap", marginBottom: "0.5rem" }}
+          style={{
+            padding: "20px 24px",
+            borderRadius: "12px",
+            background: "#fef2f2",
+            border: "1px solid #fecaca",
+          }}
         >
-          <p style={{ margin: 0, color: "#a32e2e", fontWeight: 600 }}>{error}</p>
+          <p style={{ margin: 0, color: "#991b1b", fontWeight: 600, marginBottom: "8px" }}>
+            {"Unable to preview this file"}
+          </p>
+          <p style={{ margin: 0, color: "#b91c1c", fontSize: "0.92rem" }}>{error}</p>
           {downloadUrl && (
             <a
               href={downloadUrl}
               target="_blank"
               rel="noopener noreferrer"
-              style={{ color: "#036A53", fontWeight: 600, textDecoration: "underline" }}
+              style={{
+                display: "inline-block",
+                marginTop: "12px",
+                color: "#036A53",
+                fontWeight: 600,
+                textDecoration: "underline",
+              }}
             >
-              {"Download file"}
+              {"Download file instead"}
             </a>
           )}
         </div>
       ) : (
-        <p style={{ margin: "0 0 0.5rem 0", color: "#4a4740" }}>
-          {isLoading ? `Importing model... ${elapsedSeconds}s` : "Model loaded."}
-        </p>
-      )}
+        <>
+          {/* Loading status */}
+          <p style={{ margin: "0 0 0.5rem 0", color: "#4a4740" }}>
+            {isLoading ? `Importing model... ${elapsedSeconds}s` : "Model loaded."}
+          </p>
 
-      {isLoading && elapsedSeconds > 8 && (
-        <p style={{ margin: "0 0 0.5rem 0", color: "#6a665d", fontSize: "0.95rem" }}>
-          {"Large STEP files can take 20-90 seconds to parse in the browser, especially on first load."}
-        </p>
-      )}
+          {isLoading && elapsedSeconds > 8 && (
+            <p style={{ margin: "0 0 0.5rem 0", color: "#6a665d", fontSize: "0.95rem" }}>
+              {"Large STEP files can take 20-90 seconds to parse in the browser, especially on first load."}
+            </p>
+          )}
 
-      <div
-        ref={viewerContainerRef}
-        style={{
-          width: "100%",
-          height: height,
-          borderRadius: "18px",
-          border: "1px solid #d0ccc3",
-          boxShadow: "0 12px 40px rgba(76, 72, 61, 0.13)",
-          background: "#f7f7f5",
-          overflow: "hidden",
-        }}
-      />
+          {/* Viewer container — hidden when errored */}
+          <div
+            ref={viewerContainerRef}
+            style={{
+              width: "100%",
+              height: height,
+              borderRadius: "18px",
+              border: "1px solid #d0ccc3",
+              boxShadow: "0 12px 40px rgba(76, 72, 61, 0.13)",
+              background: "#f7f7f5",
+              overflow: "hidden",
+            }}
+          />
+        </>
+      )}
 
       {showControls && !isLoading && !error && (
         <div

--- a/components/partials/create/project/steps/ModelFilesStep.tsx
+++ b/components/partials/create/project/steps/ModelFilesStep.tsx
@@ -1,60 +1,133 @@
-import { Stack } from "@bbtgnn/polaris-interfacer";
-import PError from "components/polaris/PError";
-import PFileUpload from "components/polaris/PFileUpload";
+import { Stack, TextField } from "@bbtgnn/polaris-interfacer";
 import PTitleSubtitle from "components/polaris/PTitleSubtitle";
-import { formSetValueOptions } from "lib/formSetValueOptions";
 import { useTranslation } from "next-i18next";
 import { useFormContext } from "react-hook-form";
 import * as yup from "yup";
 import { CreateProjectValues } from "../CreateProjectForm";
 
-export type ModelFilesStepValues = Array<File>;
-export const modelFilesStepSchema = () => yup.array().default([]);
+export type ModelFilesStepValues = Array<{ url: string }>;
+
+export const modelFilesStepSchema = () =>
+  yup
+    .array()
+    .of(
+      yup.object({
+        url: yup.string().url().required(),
+      })
+    )
+    .default([]);
+
 export const modelFilesStepDefaultValues: ModelFilesStepValues = [];
 
 const allowedExtensions = new Set(["step", "stp", "stl"]);
-const maxFileSize = 50000000;
 
-function getExtension(fileName: string): string {
-  return fileName.split(".").pop()?.toLowerCase() || "";
+function getExtension(url: string): string {
+  try {
+    const pathname = new URL(url).pathname;
+    return pathname.split(".").pop()?.toLowerCase() || "";
+  } catch {
+    return "";
+  }
+}
+
+function isValidCadUrl(url: string): boolean {
+  if (!url) return false;
+  try {
+    new URL(url);
+    const ext = getExtension(url);
+    return allowedExtensions.has(ext);
+  } catch {
+    return false;
+  }
 }
 
 export default function ModelFilesStep() {
   const { t } = useTranslation("createProjectProps");
   const { setValue, watch, formState } = useFormContext<CreateProjectValues>();
   const { errors } = formState;
-  const modelFiles = watch().modelFiles;
-  const modelFilesError = errors.modelFiles?.message;
 
-  function handleUpdate(files: Array<File>) {
-    setValue("modelFiles", files, formSetValueOptions);
+  const modelFiles = watch("modelFiles") || [];
+
+  function handleUrlChange(index: number, url: string) {
+    const updated = [...modelFiles];
+    updated[index] = { url };
+    setValue("modelFiles", updated, { shouldValidate: true, shouldDirty: true });
+  }
+
+  function handleAddUrl() {
+    setValue("modelFiles", [...modelFiles, { url: "" }], { shouldValidate: false, shouldDirty: true });
+  }
+
+  function handleRemoveUrl(index: number) {
+    const updated = modelFiles.filter((_: unknown, i: number) => i !== index);
+    setValue("modelFiles", updated, { shouldValidate: true, shouldDirty: true });
   }
 
   return (
     <Stack vertical spacing="extraLoose">
       <PTitleSubtitle
-        title={t("Upload 3D and CAD files")}
+        title={t("Add CAD files")}
         subtitle={t(
-          "Attach fabrication-ready 3D files and CAD models for this design. You can upload many files — they will be viewable and downloadable from the design detail page."
+          "Provide links to STEP, STP or STL files for your design. These will be viewable directly in your browser from the design detail page — no upload needed."
         )}
       />
-      <div>
-        <PFileUpload
-          files={modelFiles}
-          onUpdate={handleUpdate}
-          accept="file"
-          maxSize={maxFileSize}
-          label={t("Upload STEP, STP or STL files")}
-          helpText={`${t("Max file size")}: 50MB | ${t("Accepted formats")}: STEP, STP, STL`}
-          customValidators={[
-            file => ({
-              valid: allowedExtensions.has(getExtension(file.name)),
-              message: t("Only STEP, STP, and STL files are supported"),
-            }),
-          ]}
-        />
-        {modelFilesError && <PError error={String(modelFilesError)} />}
-      </div>
+
+      {/* Existing URL fields */}
+      {modelFiles.map((entry: { url: string }, index: number) => (
+        <div key={index} className="flex items-start gap-2">
+          <div className="flex-1">
+            <TextField
+              type="url"
+              id={`modelFiles.${index}.url`}
+              name={`modelFiles.${index}.url`}
+              value={entry.url}
+              autoComplete="off"
+              onChange={(value: string) => handleUrlChange(index, value)}
+              label={index === 0 ? t("CAD file URL") : t("Additional CAD file URL")}
+              placeholder="https://example.com/model.step"
+              helpText={
+                !entry.url
+                  ? t("Paste a direct link to a STEP, STP or STL file")
+                  : !isValidCadUrl(entry.url)
+                  ? t("URL must point to a STEP (.step, .stp) or STL (.stl) file")
+                  : getExtension(entry.url).toUpperCase() + t(" file detected")
+              }
+              error={
+                !entry.url
+                  ? undefined
+                  : !isValidCadUrl(entry.url)
+                  ? t("Invalid CAD file URL — must be a STEP or STL file")
+                  : undefined
+              }
+              requiredIndicator={index === 0}
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => handleRemoveUrl(index)}
+            className="mt-7 inline-flex items-center justify-center w-9 h-9 rounded-full border border-ifr bg-transparent cursor-pointer transition-colors hover:bg-red-50 hover:border-red-300"
+            aria-label={t("Remove URL")}
+            style={{ color: "var(--ifr-text-secondary)" }}
+          >
+            {"\u00d7"}
+          </button>
+        </div>
+      ))}
+
+      {/* Add another URL button */}
+      <button
+        type="button"
+        onClick={handleAddUrl}
+        className="inline-flex items-center gap-1.5 px-4 py-2 border border-ifr rounded-ifr-sm bg-transparent cursor-pointer transition-colors hover:bg-ifr-hover"
+        style={{
+          fontFamily: "var(--ifr-font-body)",
+          fontSize: "var(--ifr-fs-base)",
+          color: "var(--ifr-text-secondary)",
+        }}
+      >
+        <span className="text-lg leading-none">+</span>
+        {t("Add another CAD file")}
+      </button>
     </Stack>
   );
 }

--- a/hooks/useProjectCRUD.ts
+++ b/hooks/useProjectCRUD.ts
@@ -12,7 +12,6 @@ import {
   prefixedTag,
   TAG_PREFIX,
 } from "lib/tagging";
-import { uploadModelFilesToDpp } from "lib/projectModelFiles";
 import { useTranslation } from "next-i18next";
 import { LocationStepValues } from "components/partials/create/project/steps/LocationStep";
 import { useAuth } from "./useAuth";
@@ -180,6 +179,11 @@ export const useProjectCRUD = () => {
         ])
       );
 
+      // Model file URLs (stored as plain strings in metadata.models)
+      const modelUrls = (formData.modelFiles || [])
+        .map(m => m.url?.trim())
+        .filter((url): url is string => Boolean(url));
+
       // Metadata
       const metadata: Record<string, unknown> = {
         contributors: formData.contributors,
@@ -189,6 +193,7 @@ export const useProjectCRUD = () => {
         remote: formData.location.remote || projectType === ProjectType.DESIGN,
         design: formData.linkedDesign || false,
         image: imageUrls.length === 1 ? imageUrls[0] : imageUrls,
+        ...(modelUrls.length > 0 && { models: modelUrls }),
       };
 
       // Create project

--- a/pages/project/[id]/edit/model.tsx
+++ b/pages/project/[id]/edit/model.tsx
@@ -14,43 +14,27 @@ import ModelFilesStep, {
 } from "components/partials/create/project/steps/ModelFilesStep";
 import EditFormLayout from "components/partials/project/edit/EditFormLayout";
 import { useProjectCRUD } from "hooks/useProjectCRUD";
-import useDppApi from "lib/dpp";
 import findProjectModels, { getRawMetadataModelEntries } from "lib/findProjectModels";
-import { uploadModelFilesToDpp } from "lib/projectModelFiles";
-
-type ModelMetadataEntry = string | Record<string, unknown>;
 
 interface EditModelFilesValues {
   modelFiles: ModelFilesStepValues;
 }
 
-const SEPARATOR = " @ ";
-
-function createToken(entry: ReturnType<typeof findProjectModels>[number], index: number): string {
-  return entry.hash || entry.url || `${entry.name}-${index}`;
-}
-
 const EditModelFiles: NextPageWithLayout = () => {
   const { project } = useProject();
   const { updateMetadata } = useProjectCRUD();
-  const { uploadFile: uploadDppFile } = useDppApi();
 
   const metadata = ((project.metadata || {}) as Record<string, unknown>) || {};
   const existingEntries = getRawMetadataModelEntries(metadata);
   const resolvedModels = findProjectModels(project);
 
-  const existingModels = resolvedModels.map((model, index) => {
-    const token = createToken(model, index);
-
-    return {
-      entry: existingEntries[index] as ModelMetadataEntry,
-      file: new File([], `${model.name}${SEPARATOR}${token}`),
-      token,
-    };
-  });
+  // Map existing models to {url} entries
+  const existingModelUrls: ModelFilesStepValues = resolvedModels.map(model => ({
+    url: model.url,
+  }));
 
   const defaultValues: EditModelFilesValues = {
-    modelFiles: existingModels.map(model => model.file),
+    modelFiles: existingModelUrls,
   };
 
   const schema = yup.object({
@@ -63,25 +47,15 @@ const EditModelFiles: NextPageWithLayout = () => {
     defaultValues,
   });
 
-  function getExistingEntry(fileName: string): ModelMetadataEntry | undefined {
-    const fileNameParts = fileName.split(SEPARATOR);
-    const token = fileNameParts[fileNameParts.length - 1];
-    return existingModels.find(model => model.token === token)?.entry;
-  }
-
-  function isExistingEntry(fileName: string): boolean {
-    return Boolean(getExistingEntry(fileName));
-  }
-
   async function onSubmit(values: EditModelFilesValues) {
-    const preservedEntries = values.modelFiles
-      .map(file => getExistingEntry(file.name))
-      .filter((entry): entry is ModelMetadataEntry => Boolean(entry));
+    const newModelUrls = (values.modelFiles || []).map(m => m.url?.trim()).filter((url): url is string => Boolean(url));
 
-    const newFiles = values.modelFiles.filter(file => !isExistingEntry(file.name));
-    const newEntries = await uploadModelFilesToDpp(newFiles, uploadDppFile);
+    // Preserve any existing non-URL entries (e.g. DPP-stored files)
+    const preservedEntries = existingEntries.filter(entry => typeof entry !== "string");
 
-    await updateMetadata(project, { models: [...preservedEntries, ...newEntries] });
+    await updateMetadata(project, {
+      models: [...preservedEntries, ...newModelUrls],
+    });
   }
 
   return (


### PR DESCRIPTION
ModelFilesStep now accepts STEP/STP/STL file URLs instead of file
uploads. URLs are stored as plain strings in metadata.models and
rendered client-side by the existing StepModelViewer — no DPP
storage or remote upload required.

Also simplified the edit model page to work with URL entries.
