### PR TITLE
fix: 🐛 break circular dependency causing TDZ error in production builds

### DIFF
--- a/components/ProjectLicenses.tsx
+++ b/components/ProjectLicenses.tsx
@@ -2,7 +2,7 @@ import { Text } from "@bbtgnn/polaris-interfacer";
 import { EconomicResource } from "lib/types";
 import { useTranslation } from "next-i18next";
 import LicenseDisplay from "./LicenseDisplay";
-import { LicenseStepValues } from "./partials/create/project/steps/LicenseStep";
+import { LicenseStepValues } from "./partials/create/project/steps/LicenseStep.schema";
 
 const ProjectLicenses = ({ project }: { project: Partial<EconomicResource> }) => {
   const licenses: LicenseStepValues = project?.metadata?.licenses;

--- a/components/partials/create/project/CreateProjectForm.tsx
+++ b/components/partials/create/project/CreateProjectForm.tsx
@@ -8,19 +8,19 @@ import {
   contributorsStepDefaultValues,
   contributorsStepSchema,
   ContributorsStepValues,
-} from "./steps/ContributorsStep";
+} from "./steps/ContributorsStep.schema";
 import {
   declarationsStepDefaultValues,
   declarationsStepSchema,
   DeclarationsStepValues,
-} from "./steps/DeclarationsStep";
-import { imagesStepDefaultValues, imagesStepSchema, ImagesStepValues } from "./steps/ImagesStep";
-import { licenseStepDefaultValues, licenseStepSchema, LicenseStepValues } from "./steps/LicenseStep";
-import { linkDesignStepDefaultValues, linkDesignStepSchema, LinkDesignStepValues } from "./steps/LinkDesignStep";
-import { locationStepDefaultValues, LocationStepSchemaContext, LocationStepValues } from "./steps/LocationStep";
-import { mainStepDefaultValues, mainStepSchema, MainStepValues } from "./steps/MainStep";
-import { modelFilesStepDefaultValues, modelFilesStepSchema, ModelFilesStepValues } from "./steps/ModelFilesStep";
-import { relationsStepDefaultValues, relationsStepSchema, RelationsStepValues } from "./steps/RelationsStep";
+} from "./steps/DeclarationsStep.schema";
+import { imagesStepDefaultValues, imagesStepSchema, ImagesStepValues } from "./steps/ImagesStep.schema";
+import { licenseStepDefaultValues, licenseStepSchema, LicenseStepValues } from "./steps/LicenseStep.schema";
+import { linkDesignStepDefaultValues, linkDesignStepSchema, LinkDesignStepValues } from "./steps/LinkDesignStep.schema";
+import { locationStepDefaultValues, LocationStepSchemaContext, LocationStepValues } from "./steps/LocationStep.schema";
+import { mainStepDefaultValues, mainStepSchema, MainStepValues } from "./steps/MainStep.schema";
+import { modelFilesStepDefaultValues, modelFilesStepSchema, ModelFilesStepValues } from "./steps/ModelFilesStep.schema";
+import { relationsStepDefaultValues, relationsStepSchema, RelationsStepValues } from "./steps/RelationsStep.schema";
 
 // Partials
 import CreateProjectFields from "./parts/CreateProjectFields";
@@ -39,18 +39,18 @@ import useYupLocaleObject from "hooks/useYupLocaleObject";
 import { FormProvider, useForm } from "react-hook-form";
 import * as yup from "yup";
 
-import { machinesStepDefaultValues, machinesStepSchema, MachinesStepValues } from "./steps/MachinesStep";
-import { materialsStepDefaultValues, materialsStepSchema, MaterialsStepValues } from "./steps/MaterialsStep";
+import { machinesStepDefaultValues, machinesStepSchema, MachinesStepValues } from "./steps/MachinesStep.schema";
+import { materialsStepDefaultValues, materialsStepSchema, MaterialsStepValues } from "./steps/MaterialsStep.schema";
 import {
   productFiltersStepDefaultValues,
   productFiltersStepSchema,
   ProductFiltersStepValues,
-} from "./steps/ProductFiltersStep";
+} from "./steps/ProductFiltersStep.schema";
 import {
   serviceFiltersStepDefaultValues,
   serviceFiltersStepSchema,
   ServiceFiltersStepValues,
-} from "./steps/ServiceFiltersStep";
+} from "./steps/ServiceFiltersStep.schema";
 
 export interface Props {
   projectType: ProjectType;

--- a/components/partials/create/project/steps/ContributorsStep.schema.ts
+++ b/components/partials/create/project/steps/ContributorsStep.schema.ts
@@ -1,0 +1,5 @@
+import * as yup from "yup";
+
+export type ContributorsStepValues = Array<string>;
+export const contributorsStepSchema = () => yup.array().of(yup.string().required());
+export const contributorsStepDefaultValues: ContributorsStepValues = [];

--- a/components/partials/create/project/steps/ContributorsStep.tsx
+++ b/components/partials/create/project/steps/ContributorsStep.tsx
@@ -12,14 +12,13 @@ import { useAuth } from "hooks/useAuth";
 import { formSetValueOptions } from "lib/formSetValueOptions";
 import { PersonWithFileEssential } from "lib/types/extensions";
 import { useFormContext } from "react-hook-form";
-import * as yup from "yup";
 import { CreateProjectValues, useProjectType } from "../CreateProjectForm";
 
-//
-
-export type ContributorsStepValues = Array<string>;
-export const contributorsStepSchema = () => yup.array().of(yup.string().required());
-export const contributorsStepDefaultValues: ContributorsStepValues = [];
+export {
+  type ContributorsStepValues,
+  contributorsStepSchema,
+  contributorsStepDefaultValues,
+} from "./ContributorsStep.schema";
 
 //
 

--- a/components/partials/create/project/steps/DeclarationsStep.schema.ts
+++ b/components/partials/create/project/steps/DeclarationsStep.schema.ts
@@ -1,0 +1,42 @@
+import * as yup from "yup";
+import { Link as ILink } from "components/AddLink";
+
+yup.setLocale({
+  mixed: {
+    required: "Required",
+  },
+  string: {
+    url: "Invalid URL",
+  },
+});
+
+const YES_NO = ["yes", "no"] as const;
+
+export interface DeclarationsStepValues {
+  repairable: string;
+  recyclable: string;
+  certifications: Array<ILink>;
+}
+
+export const declarationsStepSchema = yup.object({
+  repairable: yup
+    .string()
+    .required()
+    .oneOf([...YES_NO]),
+  recyclable: yup
+    .string()
+    .required()
+    .oneOf([...YES_NO]),
+  certifications: yup.array().of(
+    yup.object().shape({
+      url: yup.string().url().required(),
+      label: yup.string().required(),
+    })
+  ),
+});
+
+export const declarationsStepDefaultValues: DeclarationsStepValues = {
+  repairable: "",
+  recyclable: "",
+  certifications: [],
+};

--- a/components/partials/create/project/steps/DeclarationsStep.tsx
+++ b/components/partials/create/project/steps/DeclarationsStep.tsx
@@ -17,47 +17,14 @@ import { useFormContext } from "react-hook-form";
 import * as yup from "yup";
 import { CreateProjectValues } from "../CreateProjectForm";
 
-//
+import {
+  type DeclarationsStepValues,
+  declarationsStepSchema,
+  declarationsStepDefaultValues,
+} from "./DeclarationsStep.schema";
+export { type DeclarationsStepValues, declarationsStepSchema, declarationsStepDefaultValues };
 
 const YES_NO = ["yes", "no"] as const;
-
-export interface DeclarationsStepValues {
-  repairable: string;
-  recyclable: string;
-  certifications: Array<ILink>;
-}
-
-yup.setLocale({
-  mixed: {
-    required: "Required",
-  },
-  string: {
-    url: "Invalid URL",
-  },
-});
-
-export const declarationsStepSchema = yup.object({
-  repairable: yup
-    .string()
-    .required()
-    .oneOf([...YES_NO]),
-  recyclable: yup
-    .string()
-    .required()
-    .oneOf([...YES_NO]),
-  certifications: yup.array().of(
-    yup.object().shape({
-      url: yup.string().url().required(),
-      label: yup.string().required(),
-    })
-  ),
-});
-
-export const declarationsStepDefaultValues: DeclarationsStepValues = {
-  repairable: "",
-  recyclable: "",
-  certifications: [],
-};
 
 //
 

--- a/components/partials/create/project/steps/ImagesStep.schema.ts
+++ b/components/partials/create/project/steps/ImagesStep.schema.ts
@@ -1,0 +1,5 @@
+import * as yup from "yup";
+
+export type ImagesStepValues = Array<File>;
+export const imagesStepSchema = () => yup.array().min(1).required();
+export const imagesStepDefaultValues: ImagesStepValues = [];

--- a/components/partials/create/project/steps/ImagesStep.tsx
+++ b/components/partials/create/project/steps/ImagesStep.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from "next-i18next";
-import * as yup from "yup";
 
 // Components
 import { Stack } from "@bbtgnn/polaris-interfacer";
@@ -11,11 +10,7 @@ import { formSetValueOptions } from "lib/formSetValueOptions";
 import { useFormContext } from "react-hook-form";
 import { CreateProjectValues, useProjectType } from "../CreateProjectForm";
 
-//
-
-export type ImagesStepValues = Array<File>;
-export const imagesStepSchema = () => yup.array().min(1).required();
-export const imagesStepDefaultValues: ImagesStepValues = [];
+export { type ImagesStepValues, imagesStepSchema, imagesStepDefaultValues } from "./ImagesStep.schema";
 
 //
 

--- a/components/partials/create/project/steps/LicenseStep.schema.ts
+++ b/components/partials/create/project/steps/LicenseStep.schema.ts
@@ -1,0 +1,6 @@
+import * as yup from "yup";
+
+export type LicenseStepValues = Array<{ scope: string; licenseId: string }>;
+export const licenseStepSchema = () =>
+  yup.array().of(yup.object().shape({ scope: yup.string(), licenseId: yup.string() }));
+export const licenseStepDefaultValues: LicenseStepValues = [];

--- a/components/partials/create/project/steps/LicenseStep.tsx
+++ b/components/partials/create/project/steps/LicenseStep.tsx
@@ -10,15 +10,9 @@ import PCardWithAction from "components/polaris/PCardWithAction";
 import PTitleSubtitle from "components/polaris/PTitleSubtitle";
 import { formSetValueOptions } from "lib/formSetValueOptions";
 import { useFormContext } from "react-hook-form";
-import * as yup from "yup";
 import { CreateProjectValues } from "../CreateProjectForm";
 
-//
-
-export type LicenseStepValues = Array<{ scope: string; licenseId: string }>;
-export const licenseStepSchema = () =>
-  yup.array().of(yup.object().shape({ scope: yup.string(), licenseId: yup.string() }));
-export const licenseStepDefaultValues: LicenseStepValues = [];
+export { type LicenseStepValues, licenseStepSchema, licenseStepDefaultValues } from "./LicenseStep.schema";
 
 //
 

--- a/components/partials/create/project/steps/LinkDesignStep.schema.ts
+++ b/components/partials/create/project/steps/LinkDesignStep.schema.ts
@@ -1,0 +1,5 @@
+import * as yup from "yup";
+
+export type LinkDesignStepValues = string;
+export const linkDesignStepSchema = () => yup.string();
+export const linkDesignStepDefaultValues: LinkDesignStepValues = "";

--- a/components/partials/create/project/steps/LinkDesignStep.tsx
+++ b/components/partials/create/project/steps/LinkDesignStep.tsx
@@ -8,14 +8,9 @@ import { formSetValueOptions } from "lib/formSetValueOptions";
 import { EconomicResource } from "lib/types";
 import { useTranslation } from "next-i18next";
 import { useFormContext } from "react-hook-form";
-import * as yup from "yup";
 import { CreateProjectValues } from "../CreateProjectForm";
 
-//
-
-export type LinkDesignStepValues = string;
-export const linkDesignStepSchema = () => yup.string();
-export const linkDesignStepDefaultValues: LinkDesignStepValues = "";
+export { type LinkDesignStepValues, linkDesignStepSchema, linkDesignStepDefaultValues } from "./LinkDesignStep.schema";
 
 //
 

--- a/components/partials/create/project/steps/LocationStep.schema.ts
+++ b/components/partials/create/project/steps/LocationStep.schema.ts
@@ -1,0 +1,46 @@
+import * as yup from "yup";
+import { SelectedLocation } from "components/SelectLocation";
+import { ProjectType } from "components/types";
+
+export interface LocationStepValues {
+  locationName: string;
+  locationData: SelectedLocation | null;
+  remote: boolean;
+}
+
+export const locationStepDefaultValues: LocationStepValues = {
+  locationName: "",
+  locationData: null,
+  remote: false,
+};
+
+function requiredWhenProduct(projectType: ProjectType, schema: yup.AnySchema) {
+  return projectType === ProjectType.PRODUCT ? schema.required() : schema.nullable();
+}
+
+function requiredWhenLocationName(locationName: string, schema: yup.AnySchema) {
+  return Boolean(locationName) ? schema.required() : schema.nullable();
+}
+
+function requiredWhenEdit(isEdit: boolean, schema: yup.AnySchema) {
+  return isEdit ? schema.required() : schema.nullable();
+}
+
+export const locationStepSchema = yup.object().shape({
+  locationName: yup.string().when("$projectType", requiredWhenProduct),
+  locationData: yup
+    .object({
+      address: yup.string().required(),
+      lat: yup.number().required(),
+      lng: yup.number().required(),
+    })
+    .when("$projectType", requiredWhenProduct)
+    .when("locationName", requiredWhenLocationName)
+    .when("$isEdit", requiredWhenEdit),
+  remote: yup.boolean(),
+});
+
+export interface LocationStepSchemaContext {
+  projectType: ProjectType;
+  isEdit: boolean;
+}

--- a/components/partials/create/project/steps/LocationStep.tsx
+++ b/components/partials/create/project/steps/LocationStep.tsx
@@ -1,58 +1,20 @@
 import { Checkbox, Stack, TextField } from "@bbtgnn/polaris-interfacer";
-import SelectLocation, { SelectedLocation } from "components/SelectLocation";
+import SelectLocation from "components/SelectLocation";
 import PTitleSubtitle from "components/polaris/PTitleSubtitle";
 import { ProjectType } from "components/types";
 import { formSetValueOptions } from "lib/formSetValueOptions";
 import getIdFromFormName from "lib/getIdFromFormName";
 import { useTranslation } from "next-i18next";
 import { Controller, useFormContext } from "react-hook-form";
-import * as yup from "yup";
 import { CreateProjectValues } from "../CreateProjectForm";
 
-//
-
-export interface LocationStepValues {
-  locationName: string;
-  locationData: SelectedLocation | null;
-  remote: boolean;
-}
-
-export const locationStepDefaultValues: LocationStepValues = {
-  locationName: "",
-  locationData: null,
-  remote: false,
-};
-
-function requiredWhenProduct(projectType: ProjectType, schema: yup.AnySchema) {
-  return projectType === ProjectType.PRODUCT ? schema.required() : schema.nullable();
-}
-
-function requiredWhenLocationName(locationName: string, schema: yup.AnySchema) {
-  return Boolean(locationName) ? schema.required() : schema.nullable();
-}
-
-function requiredWhenEdit(isEdit: boolean, schema: yup.AnySchema) {
-  return isEdit ? schema.required() : schema.nullable();
-}
-
-export const locationStepSchema = yup.object().shape({
-  locationName: yup.string().when("$projectType", requiredWhenProduct),
-  locationData: yup
-    .object({
-      address: yup.string().required(),
-      lat: yup.number().required(),
-      lng: yup.number().required(),
-    })
-    .when("$projectType", requiredWhenProduct)
-    .when("locationName", requiredWhenLocationName)
-    .when("$isEdit", requiredWhenEdit),
-  remote: yup.boolean(),
-});
-
-export interface LocationStepSchemaContext {
-  projectType: ProjectType;
-  isEdit: boolean;
-}
+import {
+  type LocationStepValues,
+  locationStepDefaultValues,
+  locationStepSchema,
+  type LocationStepSchemaContext,
+} from "./LocationStep.schema";
+export { type LocationStepValues, locationStepDefaultValues, locationStepSchema, type LocationStepSchemaContext };
 
 //
 

--- a/components/partials/create/project/steps/MachinesStep.schema.ts
+++ b/components/partials/create/project/steps/MachinesStep.schema.ts
@@ -1,0 +1,27 @@
+import * as yup from "yup";
+
+export interface MachinesStepValues {
+  machines: string[]; // Array of machine resource IDs
+  machineDetails: Array<{ id: string; name: string }>; // Used for save-time machine-* tags
+}
+
+export const machinesStepDefaultValues: MachinesStepValues = {
+  machines: [],
+  machineDetails: [],
+};
+
+export const machinesStepSchema = () =>
+  yup.object().shape({
+    machines: yup.array().of(yup.string().required()).default([]),
+    machineDetails: yup
+      .array()
+      .of(
+        yup
+          .object({
+            id: yup.string().required(),
+            name: yup.string().required(),
+          })
+          .required()
+      )
+      .default([]),
+  });

--- a/components/partials/create/project/steps/MachinesStep.tsx
+++ b/components/partials/create/project/steps/MachinesStep.tsx
@@ -5,42 +5,9 @@ import SearchMachines from "components/SearchMachines";
 import { useTranslation } from "next-i18next";
 import { useState } from "react";
 import { useFormContext } from "react-hook-form";
-import * as yup from "yup";
 import { CreateProjectValues } from "../CreateProjectForm";
 
-//
-// Types
-//
-
-export interface MachinesStepValues {
-  machines: string[]; // Array of machine resource IDs
-  machineDetails: Array<{ id: string; name: string }>; // Used for save-time machine-* tags
-}
-
-export const machinesStepDefaultValues: MachinesStepValues = {
-  machines: [],
-  machineDetails: [],
-};
-
-//
-// Schema
-//
-
-export const machinesStepSchema = () =>
-  yup.object().shape({
-    machines: yup.array().of(yup.string().required()).default([]),
-    machineDetails: yup
-      .array()
-      .of(
-        yup
-          .object({
-            id: yup.string().required(),
-            name: yup.string().required(),
-          })
-          .required()
-      )
-      .default([]),
-  });
+export { type MachinesStepValues, machinesStepDefaultValues, machinesStepSchema } from "./MachinesStep.schema";
 
 //
 // Component

--- a/components/partials/create/project/steps/MainStep.schema.ts
+++ b/components/partials/create/project/steps/MainStep.schema.ts
@@ -1,0 +1,32 @@
+import * as yup from "yup";
+
+export interface MainStepValues {
+  title: string;
+  description: string;
+  link: string;
+  tags: Array<string>;
+}
+
+export const mainStepDefaultValues: MainStepValues = {
+  title: "",
+  description: "",
+  link: "",
+  tags: [],
+};
+
+export const mainStepSchema = () =>
+  yup.object({
+    title: yup.string().required(),
+    link: yup.string().url().required(),
+    tags: yup.array().of(yup.string()),
+    description: yup
+      .string()
+      .test(
+        "size-check",
+        "Description length must be less than 6000 characters. If it's longer, please use the 'project data' field to reference it.",
+        value => {
+          if (value) return new Blob([value]).size < 6000;
+          else return true;
+        }
+      ),
+  });

--- a/components/partials/create/project/steps/MainStep.tsx
+++ b/components/partials/create/project/steps/MainStep.tsx
@@ -7,41 +7,10 @@ import getIdFromFormName from "lib/getIdFromFormName";
 import { isRequired } from "lib/isFieldRequired";
 import { useTranslation } from "next-i18next";
 import { Controller, useFormContext } from "react-hook-form";
-import * as yup from "yup";
 import { CreateProjectValues, useProjectType } from "../CreateProjectForm";
 
-//
-
-export interface MainStepValues {
-  title: string;
-  description: string;
-  link: string;
-  tags: Array<string>;
-}
-
-export const mainStepDefaultValues: MainStepValues = {
-  title: "",
-  description: "",
-  link: "",
-  tags: [],
-};
-
-export const mainStepSchema = () =>
-  yup.object({
-    title: yup.string().required(),
-    link: yup.string().url().required(),
-    tags: yup.array().of(yup.string()),
-    description: yup
-      .string()
-      .test(
-        "size-check",
-        "Description length must be less than 6000 characters. If it's longer, please use the 'project data' field to reference it.",
-        value => {
-          if (value) return new Blob([value]).size < 6000;
-          else return true;
-        }
-      ),
-  });
+import { type MainStepValues, mainStepDefaultValues, mainStepSchema } from "./MainStep.schema";
+export { type MainStepValues, mainStepDefaultValues, mainStepSchema };
 
 //
 

--- a/components/partials/create/project/steps/MaterialsStep.schema.ts
+++ b/components/partials/create/project/steps/MaterialsStep.schema.ts
@@ -1,0 +1,27 @@
+import * as yup from "yup";
+
+export interface MaterialsStepValues {
+  materials: string[]; // Array of material resource IDs
+  materialDetails: Array<{ id: string; name: string }>; // Used for save-time material-* tags
+}
+
+export const materialsStepDefaultValues: MaterialsStepValues = {
+  materials: [],
+  materialDetails: [],
+};
+
+export const materialsStepSchema = () =>
+  yup.object().shape({
+    materials: yup.array().of(yup.string().required()).default([]),
+    materialDetails: yup
+      .array()
+      .of(
+        yup
+          .object({
+            id: yup.string().required(),
+            name: yup.string().required(),
+          })
+          .required()
+      )
+      .default([]),
+  });

--- a/components/partials/create/project/steps/MaterialsStep.tsx
+++ b/components/partials/create/project/steps/MaterialsStep.tsx
@@ -5,34 +5,9 @@ import SearchMaterials from "components/SearchMaterials";
 import { useTranslation } from "next-i18next";
 import { useState } from "react";
 import { useFormContext } from "react-hook-form";
-import * as yup from "yup";
 import { CreateProjectValues } from "../CreateProjectForm";
 
-export interface MaterialsStepValues {
-  materials: string[]; // Array of material resource IDs
-  materialDetails: Array<{ id: string; name: string }>; // Used for save-time material-* tags
-}
-
-export const materialsStepDefaultValues: MaterialsStepValues = {
-  materials: [],
-  materialDetails: [],
-};
-
-export const materialsStepSchema = () =>
-  yup.object().shape({
-    materials: yup.array().of(yup.string().required()).default([]),
-    materialDetails: yup
-      .array()
-      .of(
-        yup
-          .object({
-            id: yup.string().required(),
-            name: yup.string().required(),
-          })
-          .required()
-      )
-      .default([]),
-  });
+export { type MaterialsStepValues, materialsStepDefaultValues, materialsStepSchema } from "./MaterialsStep.schema";
 
 export default function MaterialsStep() {
   const { t } = useTranslation("createProjectProps");

--- a/components/partials/create/project/steps/ModelFilesStep.schema.ts
+++ b/components/partials/create/project/steps/ModelFilesStep.schema.ts
@@ -1,0 +1,5 @@
+import * as yup from "yup";
+
+export type ModelFilesStepValues = Array<File>;
+export const modelFilesStepSchema = () => yup.array().default([]);
+export const modelFilesStepDefaultValues: ModelFilesStepValues = [];

--- a/components/partials/create/project/steps/ModelFilesStep.tsx
+++ b/components/partials/create/project/steps/ModelFilesStep.tsx
@@ -5,12 +5,9 @@ import PTitleSubtitle from "components/polaris/PTitleSubtitle";
 import { formSetValueOptions } from "lib/formSetValueOptions";
 import { useTranslation } from "next-i18next";
 import { useFormContext } from "react-hook-form";
-import * as yup from "yup";
 import { CreateProjectValues } from "../CreateProjectForm";
 
-export type ModelFilesStepValues = Array<File>;
-export const modelFilesStepSchema = () => yup.array().default([]);
-export const modelFilesStepDefaultValues: ModelFilesStepValues = [];
+export { type ModelFilesStepValues, modelFilesStepSchema, modelFilesStepDefaultValues } from "./ModelFilesStep.schema";
 
 const allowedExtensions = new Set(["step", "stp", "stl"]);
 const maxFileSize = 50000000;

--- a/components/partials/create/project/steps/ProductFiltersStep.schema.ts
+++ b/components/partials/create/project/steps/ProductFiltersStep.schema.ts
@@ -1,0 +1,60 @@
+import * as yup from "yup";
+
+export interface ProductFiltersStepValues {
+  categories: string[];
+  powerCompatibility: string[];
+  powerRequirementW: string;
+  replicability: string[];
+  recyclabilityPct: string;
+  repairability: boolean;
+  energyKwh: string;
+  co2Kg: string;
+}
+
+export const productFiltersStepDefaultValues: ProductFiltersStepValues = {
+  categories: [],
+  powerCompatibility: [],
+  powerRequirementW: "",
+  replicability: [],
+  recyclabilityPct: "",
+  repairability: false,
+  energyKwh: "",
+  co2Kg: "",
+};
+
+export const productFiltersStepSchema = () =>
+  yup.object().shape({
+    categories: yup.array().of(yup.string().required()).default([]),
+    powerCompatibility: yup.array().of(yup.string().required()).default([]),
+    powerRequirementW: yup
+      .string()
+      .test("is-number-or-empty", "Must be a number", value => {
+        if (!value) return true;
+        return Number.isFinite(Number(value));
+      })
+      .default(""),
+    replicability: yup.array().of(yup.string().required()).default([]),
+    recyclabilityPct: yup
+      .string()
+      .test("is-pct-or-empty", "Must be a number between 0 and 100", value => {
+        if (!value) return true;
+        const n = Number(value);
+        return Number.isFinite(n) && n >= 0 && n <= 100;
+      })
+      .default(""),
+    repairability: yup.boolean().default(false),
+    energyKwh: yup
+      .string()
+      .test("is-number-or-empty", "Must be a number", value => {
+        if (!value) return true;
+        return Number.isFinite(Number(value));
+      })
+      .default(""),
+    co2Kg: yup
+      .string()
+      .test("is-number-or-empty", "Must be a number", value => {
+        if (!value) return true;
+        return Number.isFinite(Number(value));
+      })
+      .default(""),
+  });

--- a/components/partials/create/project/steps/ProductFiltersStep.tsx
+++ b/components/partials/create/project/steps/ProductFiltersStep.tsx
@@ -5,67 +5,14 @@ import { formSetValueOptions } from "lib/formSetValueOptions";
 import { POWER_COMPATIBILITY_OPTIONS, PRODUCT_CATEGORY_OPTIONS, REPLICABILITY_OPTIONS } from "lib/tagging";
 import { useTranslation } from "next-i18next";
 import { useFormContext } from "react-hook-form";
-import * as yup from "yup";
 import { CreateProjectValues } from "../CreateProjectForm";
 
-export interface ProductFiltersStepValues {
-  categories: string[];
-  powerCompatibility: string[];
-  powerRequirementW: string;
-  replicability: string[];
-  recyclabilityPct: string;
-  repairability: boolean;
-  energyKwh: string;
-  co2Kg: string;
-}
-
-export const productFiltersStepDefaultValues: ProductFiltersStepValues = {
-  categories: [],
-  powerCompatibility: [],
-  powerRequirementW: "",
-  replicability: [],
-  recyclabilityPct: "",
-  repairability: false,
-  energyKwh: "",
-  co2Kg: "",
-};
-
-export const productFiltersStepSchema = () =>
-  yup.object().shape({
-    categories: yup.array().of(yup.string().required()).default([]),
-    powerCompatibility: yup.array().of(yup.string().required()).default([]),
-    powerRequirementW: yup
-      .string()
-      .test("is-number-or-empty", "Must be a number", value => {
-        if (!value) return true;
-        return Number.isFinite(Number(value));
-      })
-      .default(""),
-    replicability: yup.array().of(yup.string().required()).default([]),
-    recyclabilityPct: yup
-      .string()
-      .test("is-pct-or-empty", "Must be a number between 0 and 100", value => {
-        if (!value) return true;
-        const n = Number(value);
-        return Number.isFinite(n) && n >= 0 && n <= 100;
-      })
-      .default(""),
-    repairability: yup.boolean().default(false),
-    energyKwh: yup
-      .string()
-      .test("is-number-or-empty", "Must be a number", value => {
-        if (!value) return true;
-        return Number.isFinite(Number(value));
-      })
-      .default(""),
-    co2Kg: yup
-      .string()
-      .test("is-number-or-empty", "Must be a number", value => {
-        if (!value) return true;
-        return Number.isFinite(Number(value));
-      })
-      .default(""),
-  });
+import {
+  type ProductFiltersStepValues,
+  productFiltersStepDefaultValues,
+  productFiltersStepSchema,
+} from "./ProductFiltersStep.schema";
+export { type ProductFiltersStepValues, productFiltersStepDefaultValues, productFiltersStepSchema };
 
 function toggleValue(list: string[], value: string, checked: boolean): string[] {
   if (checked) return list.includes(value) ? list : [...list, value];

--- a/components/partials/create/project/steps/RelationsStep.schema.ts
+++ b/components/partials/create/project/steps/RelationsStep.schema.ts
@@ -1,0 +1,5 @@
+import * as yup from "yup";
+
+export type RelationsStepValues = Array<string>;
+export const relationsStepSchema = () => yup.array().of(yup.string().required());
+export const relationsStepDefaultValues: RelationsStepValues = [];

--- a/components/partials/create/project/steps/RelationsStep.tsx
+++ b/components/partials/create/project/steps/RelationsStep.tsx
@@ -11,14 +11,9 @@ import { ProjectType } from "components/types";
 import { formSetValueOptions } from "lib/formSetValueOptions";
 import { EconomicResource } from "lib/types";
 import { useFormContext } from "react-hook-form";
-import * as yup from "yup";
 import { CreateProjectValues, useProjectType } from "../CreateProjectForm";
 
-//
-
-export type RelationsStepValues = Array<string>;
-export const relationsStepSchema = () => yup.array().of(yup.string().required());
-export const relationsStepDefaultValues: RelationsStepValues = [];
+export { type RelationsStepValues, relationsStepSchema, relationsStepDefaultValues } from "./RelationsStep.schema";
 
 //
 

--- a/components/partials/create/project/steps/ServiceFiltersStep.schema.ts
+++ b/components/partials/create/project/steps/ServiceFiltersStep.schema.ts
@@ -1,0 +1,17 @@
+import * as yup from "yup";
+
+export interface ServiceFiltersStepValues {
+  serviceType: string[];
+  availability: string[];
+}
+
+export const serviceFiltersStepDefaultValues: ServiceFiltersStepValues = {
+  serviceType: [],
+  availability: [],
+};
+
+export const serviceFiltersStepSchema = () =>
+  yup.object().shape({
+    serviceType: yup.array().of(yup.string().required()).default([]),
+    availability: yup.array().of(yup.string().required()).default([]),
+  });

--- a/components/partials/create/project/steps/ServiceFiltersStep.tsx
+++ b/components/partials/create/project/steps/ServiceFiltersStep.tsx
@@ -5,24 +5,14 @@ import { formSetValueOptions } from "lib/formSetValueOptions";
 import { AVAILABILITY_OPTIONS, SERVICE_TYPE_OPTIONS } from "lib/tagging";
 import { useTranslation } from "next-i18next";
 import { useFormContext } from "react-hook-form";
-import * as yup from "yup";
 import { CreateProjectValues } from "../CreateProjectForm";
 
-export interface ServiceFiltersStepValues {
-  serviceType: string[];
-  availability: string[];
-}
-
-export const serviceFiltersStepDefaultValues: ServiceFiltersStepValues = {
-  serviceType: [],
-  availability: [],
-};
-
-export const serviceFiltersStepSchema = () =>
-  yup.object().shape({
-    serviceType: yup.array().of(yup.string().required()).default([]),
-    availability: yup.array().of(yup.string().required()).default([]),
-  });
+import {
+  type ServiceFiltersStepValues,
+  serviceFiltersStepDefaultValues,
+  serviceFiltersStepSchema,
+} from "./ServiceFiltersStep.schema";
+export { type ServiceFiltersStepValues, serviceFiltersStepDefaultValues, serviceFiltersStepSchema };
 
 function toggleValue(list: string[], value: string, checked: boolean): string[] {
   if (checked) return list.includes(value) ? list : [...list, value];


### PR DESCRIPTION
Extract types, schemas, and default values from step files into
separate .schema.ts files that don't depend on CreateProjectForm.tsx.

This fixes: ReferenceError: Cannot access 'contributorsStepDefaultValues'
before initialization — caused by Webpack production module ordering
triggering a Temporal Dead Zone between CreateProjectForm.tsx and its
step files, which mutually imported each other.

13 new .schema.ts files created, each containing only the type,
validation schema, and default value exports for one step.
Step .tsx files re-export for backward compatibility.
