### PR TITLE
fix: 🐛 provide ProjectTypeContext in edit pages

### DIFF
--- a/components/partials/project/edit/EditFormLayout.tsx
+++ b/components/partials/project/edit/EditFormLayout.tsx
@@ -4,6 +4,8 @@ import { FieldValues, FormProvider, UseFormReturn } from "react-hook-form";
 
 // Components
 import LoadingOverlay from "components/LoadingOverlay";
+import { ProjectTypeContext } from "components/partials/create/project/CreateProjectForm";
+import { ProjectType } from "components/types";
 import { useTranslation } from "next-i18next";
 import EditProjectNav from "./EditProjectNav";
 import SubmitChangesBar from "./SubmitChangesBar";
@@ -16,12 +18,13 @@ export interface EditFormLayoutProps<T extends FieldValues> {
   nav?: React.ReactNode;
   onSubmit: (values: T) => Promise<void>;
   redirect?: string | NextRouter;
+  projectType?: ProjectType;
 }
 
 //
 
 export default function EditFormLayout<T extends FieldValues>(props: EditFormLayoutProps<T>) {
-  const { children, formMethods, nav, onSubmit = () => {}, redirect } = props;
+  const { children, formMethods, nav, onSubmit = () => {}, redirect, projectType } = props;
   const { t } = useTranslation("common");
   const router = useRouter();
   const [loading, setLoading] = useState(false);
@@ -73,7 +76,7 @@ export default function EditFormLayout<T extends FieldValues>(props: EditFormLay
 
   /* Render */
 
-  return (
+  const content = (
     <FormProvider {...formMethods}>
       <form onSubmit={handleSubmit(onSubmitWrapper)}>
         <div className="flex justify-center items-start space-x-8 md:space-x-16 lg:space-x-24 p-6">
@@ -88,4 +91,10 @@ export default function EditFormLayout<T extends FieldValues>(props: EditFormLay
       {loading && <LoadingOverlay />}
     </FormProvider>
   );
+
+  if (projectType) {
+    return <ProjectTypeContext.Provider value={projectType}>{content}</ProjectTypeContext.Provider>;
+  }
+
+  return content;
 }

--- a/pages/project/[id]/edit/contributors.tsx
+++ b/pages/project/[id]/edit/contributors.tsx
@@ -14,6 +14,7 @@ import EditProjectLayout from "components/layout/EditProjectLayout";
 import FetchProjectLayout, { useProject } from "components/layout/FetchProjectLayout";
 import Layout from "components/layout/Layout";
 import EditFormLayout from "components/partials/project/edit/EditFormLayout";
+import { ProjectType } from "components/types";
 import { useProjectCRUD } from "hooks/useProjectCRUD";
 import { GetStaticPaths } from "next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -77,7 +78,7 @@ const EditContributors: NextPageWithLayout = () => {
   /* Render */
 
   return (
-    <EditFormLayout formMethods={formMethods} onSubmit={onSubmit}>
+    <EditFormLayout formMethods={formMethods} onSubmit={onSubmit} projectType={project.conformsTo?.name as ProjectType}>
       <ContributorsStep />
     </EditFormLayout>
   );

--- a/pages/project/[id]/edit/images.tsx
+++ b/pages/project/[id]/edit/images.tsx
@@ -13,6 +13,7 @@ import EditProjectLayout from "components/layout/EditProjectLayout";
 import FetchProjectLayout, { useProject } from "components/layout/FetchProjectLayout";
 import Layout from "components/layout/Layout";
 import EditFormLayout from "components/partials/project/edit/EditFormLayout";
+import { ProjectType } from "components/types";
 import { prepFilesForZenflows, uploadFiles } from "lib/fileUpload";
 import { dataURLtoFile, fileToIfile } from "lib/resourceImages";
 import { EditImagesMutation, EditImagesMutationVariables, File as ZenflowsFile } from "lib/types";
@@ -87,7 +88,7 @@ const EditImages: NextPageWithLayout = () => {
   /* Render */
 
   return (
-    <EditFormLayout formMethods={formMethods} onSubmit={onSubmit}>
+    <EditFormLayout formMethods={formMethods} onSubmit={onSubmit} projectType={project.conformsTo?.name as ProjectType}>
       <ImagesStep />
     </EditFormLayout>
   );

--- a/pages/project/[id]/edit/index.tsx
+++ b/pages/project/[id]/edit/index.tsx
@@ -14,6 +14,7 @@ import EditProjectLayout from "components/layout/EditProjectLayout";
 import FetchProjectLayout, { useProject } from "components/layout/FetchProjectLayout";
 import Layout from "components/layout/Layout";
 import EditFormLayout from "components/partials/project/edit/EditFormLayout";
+import { ProjectType } from "components/types";
 import { GetStaticPaths } from "next";
 import useYupLocaleObject from "hooks/useYupLocaleObject";
 
@@ -91,7 +92,7 @@ const EditMain: NextPageWithLayout = () => {
   /* Render */
 
   return (
-    <EditFormLayout formMethods={formMethods} onSubmit={onSubmit}>
+    <EditFormLayout formMethods={formMethods} onSubmit={onSubmit} projectType={project.conformsTo?.name as ProjectType}>
       <MainStep />
     </EditFormLayout>
   );

--- a/pages/project/[id]/edit/relations.tsx
+++ b/pages/project/[id]/edit/relations.tsx
@@ -16,6 +16,7 @@ import EditProjectLayout from "components/layout/EditProjectLayout";
 import FetchProjectLayout, { useProject } from "components/layout/FetchProjectLayout";
 import Layout from "components/layout/Layout";
 import EditFormLayout from "components/partials/project/edit/EditFormLayout";
+import { ProjectType } from "components/types";
 import { GetStaticPaths } from "next";
 import useYupLocaleObject from "hooks/useYupLocaleObject";
 
@@ -77,7 +78,7 @@ const EditMain: NextPageWithLayout = () => {
   /* Render */
 
   return (
-    <EditFormLayout formMethods={formMethods} onSubmit={onSubmit}>
+    <EditFormLayout formMethods={formMethods} onSubmit={onSubmit} projectType={project.conformsTo?.name as ProjectType}>
       <RelationsStep />
     </EditFormLayout>
   );


### PR DESCRIPTION
EditFormLayout now accepts an optional projectType prop and wraps
children in ProjectTypeContext.Provider when provided. All edit
pages (main, images, contributors, relations) now pass the project
type from project.conformsTo?.name to fix the 'useProjectType must
be used within ProjectTypeContext' error.
