### PR TITLE
fix: 🐛 upload profile image binary to Zenflows, remove unnecessary DPP upload

### DIFF
--- a/components/UpdateProfileForm.tsx
+++ b/components/UpdateProfileForm.tsx
@@ -22,8 +22,9 @@ import ProfileImageEditor from "./partials/profile/[id]/ProfileImageEditor";
 import { Card, Stack, TextField } from "@bbtgnn/polaris-interfacer";
 import { CREATE_LOCATION } from "lib/QueryAndMutation";
 import devLog from "lib/devLog";
-import { prepFileForZenflows, uploadFile } from "lib/fileUpload";
+import { prepFileForZenflows } from "lib/fileUpload";
 import { createImageSrc, fileToIfile } from "lib/resourceImages";
+import { useAuth } from "hooks/useAuth";
 import { useRouter } from "next/router";
 import SelectLocation, { SelectedLocation } from "./SelectLocation";
 import TableOfContents from "./TableOfContents";
@@ -43,6 +44,7 @@ export interface UpdateProfileValues {
 export default function UpdateProfileForm(props: { user: Partial<Person> }) {
   const { user } = props;
   const { t } = useTranslation("common");
+  const { client } = useAuth();
   const router = useRouter();
 
   /* */
@@ -137,12 +139,16 @@ export default function UpdateProfileForm(props: { user: Partial<Person> }) {
         }
       }
 
-      if (touchedFields.image) {
-        variables.images = [await prepFileForZenflows(formData.image!)];
+      if (touchedFields.image && formData.image) {
+        variables.images = [await prepFileForZenflows(formData.image)];
       }
 
       await updateUser({ variables });
-      if (formData.image) await uploadFile(formData.image);
+
+      // Upload image binary to Zenflows file storage so images[].bin is populated
+      if (formData.image && client) {
+        await client.files.uploadToZenflows(formData.image);
+      }
     } catch (e) {
       devLog(e);
     }

--- a/components/partials/project/edit/EditFormLayout.tsx
+++ b/components/partials/project/edit/EditFormLayout.tsx
@@ -36,6 +36,7 @@ export default function EditFormLayout<T extends FieldValues>(props: EditFormLay
     setLoading(true);
     try {
       await onSubmit(values);
+      setLoading(false);
     } catch (e) {
       setLoading(false);
     }
@@ -65,7 +66,12 @@ export default function EditFormLayout<T extends FieldValues>(props: EditFormLay
     //
     else if (isSubmitSuccessful) {
       if (!redirect) router.reload();
-      else router.push(redirect);
+      else if (typeof redirect === "string" && router.asPath === redirect) {
+        // Already on the redirect URL — reset form state to break the infinite loop
+        // caused by react-hook-form preserving isSubmitSuccessful across same-page navigations
+        formMethods.reset();
+        setLoading(false);
+      } else router.push(redirect);
     }
 
     return () => {

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import { clearInstanceVariablesCache, InterfacerClient, createConfig } from "@dyne/interfacer-client";
+import { setFileUploadClient } from "lib/fileUpload";
 import useStorage from "hooks/useStorage";
 import { PersonWithFileEssential } from "lib/types/extensions";
 import { useRouter } from "next/router";
@@ -123,7 +124,10 @@ export const AuthProvider = ({ children, publicPage = false }: any) => {
 
   // Initialize client
   useEffect(() => {
-    setClient(createClient());
+    const c = createClient();
+    setClient(c);
+    setFileUploadClient(c);
+    return () => setFileUploadClient(null);
   }, []);
 
   // Restore session from localStorage

--- a/lib/fileUpload.ts
+++ b/lib/fileUpload.ts
@@ -18,6 +18,7 @@
  * File upload utilities — delegates to @dyne/interfacer-client SDK.
  */
 export { prepFilesForZenflows, prepFileForZenflows, formatImageSrc } from "@dyne/interfacer-client";
+import type { InterfacerClient } from "@dyne/interfacer-client";
 
 export interface IFile {
   name: string;
@@ -31,8 +32,39 @@ export interface IFile {
 export function formatZenObjects(o: Record<string, unknown>): string {
   return JSON.stringify(o, null, 4);
 }
-export async function uploadFile(_file: File) {}
-export async function uploadFiles(_files: Array<File>) {}
-export async function UploadFileOnDPP(_file: File): Promise<any> {
-  throw new Error("Use useAuth().client.files.uploadToDpp instead");
+
+/** Module-level client reference — set by AuthContext on init so uploadFile/uploadFiles work. */
+let _client: InterfacerClient | null = null;
+
+/** Called by AuthContext to register the client. */
+export function setFileUploadClient(client: InterfacerClient | null) {
+  _client = client;
+}
+
+/** Upload a single file to Zenflows file storage (so images[].bin is populated). */
+export async function uploadFile(file: File): Promise<void> {
+  if (!_client) {
+    console.warn("uploadFile: no client registered, skipping upload");
+    return;
+  }
+  try {
+    await _client.files.uploadToZenflows(file);
+  } catch (e) {
+    console.error("uploadFile failed:", e);
+  }
+}
+
+/** Upload multiple files to Zenflows file storage. */
+export async function uploadFiles(files: Array<File>): Promise<void> {
+  if (!_client) {
+    console.warn("uploadFiles: no client registered, skipping uploads");
+    return;
+  }
+  await Promise.all(files.map(file => uploadFile(file)));
+}
+
+/** Upload a single file to DPP for permanent hosting. */
+export async function UploadFileOnDPP(file: File): Promise<any> {
+  if (!_client) throw new Error("No client registered — call setFileUploadClient first");
+  return _client.files.uploadToDpp(file);
 }


### PR DESCRIPTION
- Restore uploadFile/uploadFiles to actually POST binary to Zenflows file storage
  (previously no-ops, causing images[].bin to always be null)
- Wire client into AuthContext so fileUpload module has access to the SDK
- Drop uploadToDpp from UpdateProfileForm — Zenflows bin is sufficient for avatars
- Fix EditFormLayout infinite redirect loop on same-page submissions
