### PR TITLE
refactor: consume FeedbackClient from @dyne/interfacer-client SDK

### DIFF
--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -85,6 +85,7 @@ function createClient() {
       zenflowsUrl: process.env.NEXT_PUBLIC_ZENFLOWS_URL || "",
       zenflowsFileUrl: process.env.NEXT_PUBLIC_ZENFLOWS_FILE_URL || "",
       dppUrl: process.env.NEXT_PUBLIC_DPP_URL || "",
+      feedbackUrl: process.env.NEXT_PUBLIC_FEEDBACK_URL || "",
       inbox: {
         send: process.env.NEXT_PUBLIC_INBOX_SEND || "",
         read: process.env.NEXT_PUBLIC_INBOX_READ || "",

--- a/lib/feedback.ts
+++ b/lib/feedback.ts
@@ -1,60 +1,25 @@
 /**
- * API client for the interfacer-feedback-service REST backend.
+ * Feedback hook — thin wrapper around client.feedback SDK module.
+ *
  * Provides a React hook `useFeedbackApi` with typed methods for reviews and comments.
- *
- * Auth: Signs requests with EdDSA keys via did-sign/did-pk headers
- * (same pattern as useDppApi / lib/dpp.ts).
- *
- * @see ~/dyne/interfacer-feedback-service/cmd/main/main.go for route definitions
+ * Now delegates all HTTP + signing to the SDK's FeedbackClient instead of raw fetch.
  */
 
-// @ts-ignore
 import { useAuth } from "hooks/useAuth";
-import { useCallback, useMemo } from "react";
-// @ts-ignore
-import sign from "zenflows-crypto/src/sign_graphql.zen";
+import {
+  type Review,
+  type ReviewSummary,
+  type Comment,
+  type GetReviewsParams,
+  type GetCommentsParams,
+} from "@dyne/interfacer-client";
+import { useMemo } from "react";
 
-const FEEDBACK_BASE_URL = process.env.NEXT_PUBLIC_FEEDBACK_URL;
-
-// ---------------------------------------------------------------------------
-// Types (mirrors interfacer-feedback-service/internal/model/model.go)
-// ---------------------------------------------------------------------------
-
-export interface Review {
-  id: string;
-  project_ulid: string;
-  user_ulid: string;
-  rating: number; // 1-5
-  content?: string | null;
-  created_at: string; // ISO 8601 / RFC 3339
-  updated_at: string;
-}
-
-export interface ReviewSummary {
-  average_rating: number;
-  total_reviews: number;
-  rating_distribution: Record<number, number>; // rating (1-5) -> count
-}
-
-export interface Comment {
-  id: string;
-  project_ulid: string;
-  user_ulid: string;
-  parent_id?: string | null;
-  content: string;
-  attachments?: string | null; // JSON array of file IDs/URLs
-  status: string; // 'active' | 'deleted'
-  created_at: string;
-  updated_at: string;
-}
-
-export interface FeedbackApiError {
-  error: string;
-  details?: string;
-}
+// Re-export types for backward compatibility
+export type { Review, ReviewSummary, Comment, GetReviewsParams, GetCommentsParams } from "@dyne/interfacer-client";
 
 // ---------------------------------------------------------------------------
-// Request error
+// Request error (retained for backward compat)
 // ---------------------------------------------------------------------------
 
 class FeedbackRequestError extends Error {
@@ -70,202 +35,49 @@ class FeedbackRequestError extends Error {
 }
 
 export { FeedbackRequestError };
-
-// ---------------------------------------------------------------------------
-// Review list / pagination params
-// ---------------------------------------------------------------------------
-
-export interface GetReviewsParams {
-  limit?: number; // max 100, default 20
-  cursor?: number; // Unix timestamp of last item from previous page
-}
-
-export interface GetCommentsParams {
-  limit?: number;
-  cursor?: number;
-  parent_id?: string; // fetch replies for a specific parent comment
-}
+export type FeedbackApiError = { error: string; details?: string };
 
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
 
 const useFeedbackApi = () => {
-  const { user } = useAuth();
+  const { user, client } = useAuth();
 
-  // --- DID signing (identical to dpp.ts) ---
+  return useMemo(() => {
+    // Return stub when client is not ready (matches pre-SDK behavior)
+    const empty = () => {
+      throw new Error("Feedback API not available");
+    };
 
-  const signBody = useCallback(
-    async (body: string): Promise<{ "did-sign": string; "did-pk": string }> => {
-      const zencode_exec = (await import("zenroom")).zencode_exec;
-      const eddsaKey = typeof window !== "undefined" ? window.localStorage.getItem("eddsaPrivateKey") || "" : "";
-      const data = `{"gql": "${Buffer.from(body, "utf8").toString("base64")}"}`;
-      const keys = `{"keyring": {"eddsa": "${eddsaKey}"}}`;
-      const { result } = await zencode_exec(sign, { data, keys });
-      return {
-        "did-sign": JSON.parse(result).eddsa_signature,
-        "did-pk": String(user?.publicKey),
-      };
-    },
-    [user?.publicKey]
-  );
+    return {
+      createReview: client
+        ? (projectUlid: string, rating: number, content?: string) =>
+            client.feedback.createReview(projectUlid, rating, content)
+        : empty,
 
-  // --- Generic request helper ---
+      getReviews: client
+        ? (projectUlid: string, params?: GetReviewsParams) => client.feedback.getReviews(projectUlid, params)
+        : empty,
 
-  const request = useCallback(
-    async <T>(method: string, path: string, body?: any): Promise<T> => {
-      const url = `${FEEDBACK_BASE_URL}${path}`;
-      const jsonBody = body != null ? JSON.stringify(body) : undefined;
+      getReviewSummary: client ? (projectUlid: string) => client.feedback.getReviewSummary(projectUlid) : empty,
 
-      const headers: Record<string, string> = {};
+      getUserReview: client ? (projectUlid: string) => client.feedback.getUserReview(projectUlid) : empty,
 
-      // Always send user ULID so backend can store/filter by it
-      if (user?.ulid) {
-        headers["x-user-id"] = user.ulid;
-      }
+      deleteReview: client ? (reviewId: string) => client.feedback.deleteReview(reviewId) : empty,
 
-      // Sign all mutating requests (POST, PUT, DELETE, PATCH)
-      // even when body is empty (e.g. DELETE has no payload)
-      if (method !== "GET" && method !== "OPTIONS") {
-        const authHeaders = await signBody(jsonBody || "");
-        Object.assign(headers, authHeaders);
-        if (jsonBody) {
-          headers["Content-Type"] = "application/json";
-        }
-      }
+      createComment: client
+        ? (projectUlid: string, content: string, parentId?: string, attachments?: string) =>
+            client.feedback.createComment(projectUlid, content, parentId, attachments)
+        : empty,
 
-      const res = await fetch(url, { method, headers, body: jsonBody });
+      getComments: client
+        ? (projectUlid: string, params?: GetCommentsParams) => client.feedback.getComments(projectUlid, params)
+        : empty,
 
-      if (!res.ok) {
-        let apiError: FeedbackApiError = { error: res.statusText };
-        try {
-          apiError = await res.json();
-        } catch {
-          // response body may not be JSON
-        }
-        throw new FeedbackRequestError(apiError.error, res.status, apiError.details);
-      }
-
-      if (res.status === 204) return undefined as T;
-      return res.json();
-    },
-    [signBody, user?.ulid]
-  );
-
-  // -----------------------------------------------------------------------
-  // Reviews
-  // -----------------------------------------------------------------------
-
-  /** Create or update a review (1-5 stars + optional text). Auth required. */
-  const createReview = useCallback(
-    async (projectUlid: string, rating: number, content?: string): Promise<Review> => {
-      return request<Review>("POST", `/api/v1/projects/${encodeURIComponent(projectUlid)}/reviews`, {
-        rating,
-        content: content || null,
-      });
-    },
-    [request]
-  );
-
-  /** Fetch paginated reviews for a project. Public. */
-  const getReviews = useCallback(
-    async (projectUlid: string, params?: GetReviewsParams): Promise<{ reviews: Review[] }> => {
-      const qs = new URLSearchParams();
-      if (params?.limit != null) qs.set("limit", String(params.limit));
-      if (params?.cursor != null) qs.set("cursor", String(params.cursor));
-
-      const query = qs.toString();
-      const path = `/api/v1/projects/${encodeURIComponent(projectUlid)}/reviews${query ? `?${query}` : ""}`;
-      return request<{ reviews: Review[] }>("GET", path);
-    },
-    [request]
-  );
-
-  /** Fetch aggregated review stats for a project. Public. */
-  const getReviewSummary = useCallback(
-    async (projectUlid: string): Promise<ReviewSummary> => {
-      return request<ReviewSummary>("GET", `/api/v1/projects/${encodeURIComponent(projectUlid)}/reviews/summary`);
-    },
-    [request]
-  );
-
-  /** Fetch the current user's review for a project, or null if none exists. */
-  const getUserReview = useCallback(
-    async (projectUlid: string): Promise<{ review: Review | null }> => {
-      return request<{ review: Review | null }>(
-        "GET",
-        `/api/v1/projects/${encodeURIComponent(projectUlid)}/reviews/mine`
-      );
-    },
-    [request]
-  );
-
-  /** Delete a review by ID. Only the author can delete (enforced by backend). Auth required. */
-  const deleteReview = useCallback(
-    async (reviewId: string): Promise<{ status: string }> => {
-      return request<{ status: string }>("DELETE", `/api/v1/reviews/${encodeURIComponent(reviewId)}`, {});
-    },
-    [request]
-  );
-
-  // -----------------------------------------------------------------------
-  // Comments
-  // -----------------------------------------------------------------------
-
-  /** Post a comment (optionally as a reply to parent_id). Auth required. */
-  const createComment = useCallback(
-    async (projectUlid: string, content: string, parentId?: string, attachments?: string): Promise<Comment> => {
-      return request<Comment>("POST", `/api/v1/projects/${encodeURIComponent(projectUlid)}/comments`, {
-        content,
-        parent_id: parentId || null,
-        attachments: attachments || null,
-      });
-    },
-    [request]
-  );
-
-  /** Fetch paginated comments for a project. Public. */
-  const getComments = useCallback(
-    async (projectUlid: string, params?: GetCommentsParams): Promise<{ comments: Comment[] }> => {
-      const qs = new URLSearchParams();
-      if (params?.limit != null) qs.set("limit", String(params.limit));
-      if (params?.cursor != null) qs.set("cursor", String(params.cursor));
-      if (params?.parent_id) qs.set("parent_id", params.parent_id);
-
-      const query = qs.toString();
-      const path = `/api/v1/projects/${encodeURIComponent(projectUlid)}/comments${query ? `?${query}` : ""}`;
-      return request<{ comments: Comment[] }>("GET", path);
-    },
-    [request]
-  );
-
-  /** Soft-delete a comment. Only the author can delete (enforced by backend). Auth required. */
-  const deleteComment = useCallback(
-    async (commentId: string): Promise<{ status: string }> => {
-      // Send {} as body so signing has real data to work with (empty-body
-      // signatures can fail Zenroom verification on the backend).
-      return request<{ status: string }>("DELETE", `/api/v1/comments/${encodeURIComponent(commentId)}`, {});
-    },
-    [request]
-  );
-
-  // -----------------------------------------------------------------------
-  // Return memoized API object
-  // -----------------------------------------------------------------------
-
-  return useMemo(
-    () => ({
-      createReview,
-      getReviews,
-      getReviewSummary,
-      getUserReview,
-      deleteReview,
-      createComment,
-      getComments,
-      deleteComment,
-    }),
-    [createReview, getReviews, getReviewSummary, getUserReview, deleteReview, createComment, getComments, deleteComment]
-  );
+      deleteComment: client ? (commentId: string) => client.feedback.deleteComment(commentId) : empty,
+    };
+  }, [client]);
 };
 
 export default useFeedbackApi;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@bbtgnn/polaris-interfacer": "^0.1.0",
     "@bbtgnn/polaris-interfacer-tokens": "^6.3.0",
     "@carbon/icons-react": "^11.68.0",
-    "@dyne/interfacer-client": "^0.3.5",
+    "@dyne/interfacer-client": "^0.4.0",
     "@fontsource/ibm-plex-sans": "^5.2.8",
     "@fontsource/space-grotesk": "^5.1.10",
     "@graphql-codegen/cli": "^2.16.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^11.68.0
         version: 11.69.0(react@18.2.0)
       '@dyne/interfacer-client':
-        specifier: ^0.3.5
-        version: 0.3.5(zenroom@5.36.1)
+        specifier: ^0.4.0
+        version: 0.4.0(zenroom@5.36.1)
       '@fontsource/ibm-plex-sans':
         specifier: ^5.2.8
         version: 5.2.8
@@ -694,8 +694,8 @@ packages:
     peerDependencies:
       postcss-selector-parser: ^6.0.10
 
-  '@dyne/interfacer-client@0.3.5':
-    resolution: {integrity: sha512-gSnk9BWSZaoDSVCQPiDBCBNdoCubfWAbIukJLfcOOuxs/AUH7D5E+A+0kE8ykdC81f4WwFspTDywNQwtAzn3ww==}
+  '@dyne/interfacer-client@0.4.0':
+    resolution: {integrity: sha512-+CIq9eJZlER1isosE+ZHI9qjUF6st/qVQHvKNdtKbPp+7X4fccV0o2fCiuGMpTKufbH1siQfISNcVBUacQGC3A==}
     peerDependencies:
       zenroom: ^5.36.1
 
@@ -5833,7 +5833,7 @@ snapshots:
     dependencies:
       postcss-selector-parser: 6.1.2
 
-  '@dyne/interfacer-client@0.3.5(zenroom@5.36.1)':
+  '@dyne/interfacer-client@0.4.0(zenroom@5.36.1)':
     dependencies:
       base64url: 3.0.1
       zenroom: 5.36.1


### PR DESCRIPTION
## Summary

Replaces the raw REST + Zenroom signing code in `lib/feedback.ts` with the SDK's new `client.feedback` module.

### Before
- 231 lines of raw `fetch` + DID signing + Zenroom `zencode_exec`
- Duplicated HTTP error handling and header construction

### After
- 95 lines — thin wrapper around `client.feedback`
- Same API shape for backward compatibility
- All signing + HTTP handled by the SDK

### Depends on
- SDK v0.4.0 with FeedbackClient (https://github.com/interfacerproject/interfacer-client/pull/...)

### SDK changes
- New `FeedbackClient` class with 8 methods: `createReview`, `getReviews`, `getReviewSummary`, `getUserReview`, `deleteReview`, `createComment`, `getComments`, `deleteComment`
- Integrated as `client.feedback` on the `InterfacerClient` facade
- New `feedbackUrl` config field