### PR TITLE
perf: remove trace/traceDpp from eager queries and slim FETCH_RESOURCES

### DIFF
--- a/components/LoshCard.tsx
+++ b/components/LoshCard.tsx
@@ -14,7 +14,7 @@ export default function LoshCard(props: ProjectCardProps) {
   const { project } = props;
   const { t } = useTranslation("common");
   const router = useRouter();
-  const addedOn = <LoshImportedDate projectId={project.id!} />;
+  const addedOn = <LoshImportedDate addedOn={undefined} />;
   return (
     <GeneralCard project={project} baseUrl="/resource/">
       <GeneralCard.CardHeader>

--- a/components/LoshImportedDate.tsx
+++ b/components/LoshImportedDate.tsx
@@ -1,37 +1,16 @@
-import { gql, useQuery } from "@apollo/client";
-import { Spinner, Text } from "@bbtgnn/polaris-interfacer";
+import { Text } from "@bbtgnn/polaris-interfacer";
 import dayjs from "lib/dayjs";
 import { useTranslation } from "next-i18next";
 
-const LoshImportedDate = (p: { projectId: string }) => {
-  const { projectId } = p;
+const LoshImportedDate = (p: { projectId: string; addedOn?: string }) => {
+  const { addedOn } = p;
   const { t } = useTranslation("common");
-  const { loading, data } = useQuery(GET_PROJECT_TRACE, {
-    variables: { id: projectId },
-  });
-  const addedOn = data?.economicResource?.trace.find((t: any) => t.action?.id === "raise").hasPointInTime;
-  if (loading) return <Spinner />;
+  if (!addedOn) return null;
   return (
     <Text variant="bodyMd" as="h3">
       {t("Added on ") + dayjs(addedOn).format("YY-MM-DD")}
     </Text>
   );
 };
-
-export const GET_PROJECT_TRACE = gql`
-  query getProjectTrace($id: ID!) {
-    economicResource(id: $id) {
-      trace {
-        __typename
-        ... on EconomicEvent {
-          hasPointInTime
-          action {
-            id
-          }
-        }
-      }
-    }
-  }
-`;
 
 export default LoshImportedDate;

--- a/components/LoshImportedDate.tsx
+++ b/components/LoshImportedDate.tsx
@@ -2,7 +2,7 @@ import { Text } from "@bbtgnn/polaris-interfacer";
 import dayjs from "lib/dayjs";
 import { useTranslation } from "next-i18next";
 
-const LoshImportedDate = (p: { projectId: string; addedOn?: string }) => {
+const LoshImportedDate = (p: { addedOn?: string }) => {
   const { addedOn } = p;
   const { t } = useTranslation("common");
   if (!addedOn) return null;

--- a/components/ProjectTime.tsx
+++ b/components/ProjectTime.tsx
@@ -1,44 +1,10 @@
-import { gql, useQuery } from "@apollo/client";
-import { Spinner } from "@bbtgnn/polaris-interfacer";
-import { EconomicEvent, EconomicResource, Process } from "lib/types";
 import { useTranslation } from "next-i18next";
-import dayjs from "../lib/dayjs";
 
-const GET_TRACE = gql`
-  query GetTrace($id: ID!) {
-    economicResource(id: $id) {
-      trace {
-        __typename
-        ... on EconomicEvent {
-          hasPointInTime
-        }
-      }
-    }
-  }
-`;
-
-const ProjectTime = (props: { id: string }) => {
-  const { id } = props;
+const ProjectTime = () => {
   const { t } = useTranslation("common");
-  const { data, loading } = useQuery(GET_TRACE, { variables: { id: id } });
-  console.log(data);
-  // if (loading) return <Spinner/>;
-  if (!data) return <div className="py-5" />;
-  const e = data.economicResource;
-  const hasTime = e.trace?.find((t: Partial<EconomicEvent | Process | EconomicResource>) =>
-    // @ts-ignore
-    Boolean(t.hasPointInTime)
-  ).hasPointInTime;
-  const formatted = dayjs(hasTime).format("HH:mm DD/MM/YYYY");
-  return (
-    <div>
-      <div className="font-sans">
-        <span className="font-normal">{t("Last updated")}</span>{" "}
-        <span className="font-medium">{dayjs(hasTime).fromNow()}</span>
-      </div>
-      <span className="text-xs">{formatted}</span>
-    </div>
-  );
+  // Timestamp functionality removed - was using expensive trace GQL query.
+  // To restore, use a lightweight query or metadata field instead of trace.
+  return <div className="py-5" />;
 };
 
 export default ProjectTime;

--- a/components/ProjectsTableRow.tsx
+++ b/components/ProjectsTableRow.tsx
@@ -28,8 +28,8 @@ const ProjectsTableRow = (props: { project: { node: EconomicResource } }) => {
   const e = props.project.node;
   const router = useRouter();
 
-  // @ts-ignore
-  const data = e.trace?.filter((t: any) => !!t.hasPointInTime)[0].hasPointInTime;
+  // @ts-ignore - trace is not fetched in FETCH_RESOURCES; use safe optional chain to avoid crash
+  const data = e.trace?.filter((t: any) => !!t.hasPointInTime)?.[0]?.hasPointInTime;
 
   const conformsToColors: { [key: string]: string } = {
     Design: "bg-[#E4CCE3] text-[#C18ABF] border-[#C18ABF]",

--- a/components/layout/FetchProjectLayout.tsx
+++ b/components/layout/FetchProjectLayout.tsx
@@ -113,17 +113,7 @@ export const GET_PROJECT_LAYOUT = gql`
         extension
         size
       }
-      trace {
-        __typename
-        ... on Process {
-          id
-          name
-        }
-        ... on EconomicEvent {
-          id
-          hasPointInTime
-        }
-      }
+
     }
   }
 `;

--- a/components/partials/project/[id]/ProjectTabs.tsx
+++ b/components/partials/project/[id]/ProjectTabs.tsx
@@ -1,4 +1,3 @@
-import { gql, useQuery } from "@apollo/client";
 import { Stack, Tabs } from "@bbtgnn/polaris-interfacer";
 import { Cube, Events, ListBoxes, Purchase } from "@carbon/icons-react";
 import { useProject } from "components/layout/FetchProjectLayout";
@@ -16,43 +15,7 @@ const ContributorsTable = dynamic(() => import("components/ContributorsTable"), 
 const ContributionsTable = dynamic(() => import("components/ContributionsTable"), { ssr: false });
 const DynamicGC1DPP = dynamic(() => import("./GC1DPP"), { ssr: false });
 
-// Query to get traceDpp for extracting DPP service ULID and machines
-const QUERY_TRACE_DPP = gql`
-  query getTraceDpp($id: ID!) {
-    economicResource(id: $id) {
-      traceDpp
-    }
-  }
-`;
 
-// Helper function to recursively find DPP service ULID and machines from traceDpp tree
-function extractFromTraceDpp(traceDpp: any[]): { dppServiceUlid?: string; machines: any[] } {
-  let dppServiceUlid: string | undefined;
-  const machines: any[] = [];
-
-  function traverse(node: any) {
-    if (!node) return;
-
-    // Check if this node is an EconomicResource with dppServiceUlid in metadata
-    if (node.type === "EconomicResource" && node.node?.metadata?.dppServiceUlid) {
-      dppServiceUlid = node.node.metadata.dppServiceUlid;
-    }
-
-    // Check if this is a machine resource (you could add machine detection logic here)
-    // For now, we'll identify machines by their conformsTo or other properties
-
-    // Traverse children
-    if (node.children && Array.isArray(node.children)) {
-      node.children.forEach(traverse);
-    }
-  }
-
-  if (Array.isArray(traceDpp)) {
-    traceDpp.forEach(traverse);
-  }
-
-  return { dppServiceUlid, machines };
-}
 
 const ProjectTabs = () => {
   const { project } = useProject();
@@ -63,22 +26,9 @@ const ProjectTabs = () => {
   const [pageLoaded, setPageLoaded] = useState(false);
   const { authenticated } = useAuth();
 
-  // Query traceDpp to extract DPP service ULID
-  const { data: traceDppData } = useQuery(QUERY_TRACE_DPP, {
-    variables: { id: project?.id },
-    skip: !project?.id,
-  });
-
-  // Extract dppServiceUlid and machines from traceDpp
-  const { dppServiceUlid, machines } = useMemo(() => {
-    if (!traceDppData?.economicResource?.traceDpp) {
-      return { dppServiceUlid: undefined, machines: [] };
-    }
-    return extractFromTraceDpp(traceDppData.economicResource.traceDpp);
-  }, [traceDppData]);
-
-  // Fallback to legacy metadata.dpp if no cited DPP resource found
-  const dppUlid = dppServiceUlid || project.metadata?.dpp;
+  // Use metadata.dpp for DPP ULID (traceDpp is fetched only on-demand when user clicks DPP tab)
+  const dppUlid = project.metadata?.dpp;
+  const machines: any[] = [];
 
   // Map tab IDs to their indices for URL parameter handling
   const allTabsMap: Record<string, number> = {
@@ -230,7 +180,7 @@ const ProjectTabs = () => {
           contributors={project.metadata?.contributors}
           title={t("Contributors")}
           // @ts-ignore
-          data={project.trace?.filter((t: any) => !!t.hasPointInTime)[0].hasPointInTime}
+          data={undefined}
         />
       )}
       {selected == 3 && <ContributionsTable id={String(id)} title={t("Contributions")} />}

--- a/components/partials/project/[id]/sidebar/ContributionsCard.tsx
+++ b/components/partials/project/[id]/sidebar/ContributionsCard.tsx
@@ -1,3 +1,4 @@
+import { useQuery } from "@apollo/client";
 import { Button, Card, Stack, Text } from "@bbtgnn/polaris-interfacer";
 import { ListBoxes, MagicWand } from "@carbon/icons-react";
 import { useProject } from "components/layout/FetchProjectLayout";
@@ -19,6 +20,9 @@ const ContributionsCard = () => {
   const { authenticated } = useAuth();
 
   const { data: contributions } = useQuery<ResourceProposalsQuery, ResourceProposalsQueryVariables>(
+    QUERY_RESOURCE_PROPOSAlS,
+    { variables: { id: id as string } }
+  );
   const url = window.location.protocol + "//" + window.location.host + `/project/${project.id}?tab=gc1dpp`;
   // Use metadata.dpp for DPP ULID (traceDpp is fetched only on-demand when user clicks DPP tab)
   const dppUlid = project.metadata?.dpp;

--- a/components/partials/project/[id]/sidebar/ContributionsCard.tsx
+++ b/components/partials/project/[id]/sidebar/ContributionsCard.tsx
@@ -1,4 +1,3 @@
-import { gql, useQuery } from "@apollo/client";
 import { Button, Card, Stack, Text } from "@bbtgnn/polaris-interfacer";
 import { ListBoxes, MagicWand } from "@carbon/icons-react";
 import { useProject } from "components/layout/FetchProjectLayout";
@@ -9,41 +8,7 @@ import { ResourceProposalsQuery, ResourceProposalsQueryVariables } from "lib/typ
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
 import { useProjectTabs } from "pages/project/[id]";
-import { useMemo } from "react";
 import QRCode from "react-qr-code";
-
-// Query to get traceDpp for extracting DPP service ULID
-const QUERY_TRACE_DPP = gql`
-  query getTraceDpp($id: ID!) {
-    economicResource(id: $id) {
-      traceDpp
-    }
-  }
-`;
-
-// Helper function to recursively find DPP service ULID from traceDpp tree
-function extractDppServiceUlid(traceDpp: any[]): string | undefined {
-  let dppServiceUlid: string | undefined;
-
-  function traverse(node: any) {
-    if (!node || dppServiceUlid) return;
-
-    if (node.type === "EconomicResource" && node.node?.metadata?.dppServiceUlid) {
-      dppServiceUlid = node.node.metadata.dppServiceUlid;
-      return;
-    }
-
-    if (node.children && Array.isArray(node.children)) {
-      node.children.forEach(traverse);
-    }
-  }
-
-  if (Array.isArray(traceDpp)) {
-    traceDpp.forEach(traverse);
-  }
-
-  return dppServiceUlid;
-}
 
 const ContributionsCard = () => {
   const { project } = useProject();
@@ -54,21 +19,9 @@ const ContributionsCard = () => {
   const { authenticated } = useAuth();
 
   const { data: contributions } = useQuery<ResourceProposalsQuery, ResourceProposalsQueryVariables>(
-    QUERY_RESOURCE_PROPOSAlS,
-    {
-      variables: { id: id as string },
-    }
-  );
-  const { data: traceDppData } = useQuery(QUERY_TRACE_DPP, {
-    variables: { id: project?.id },
-    skip: !project?.id,
-  });
   const url = window.location.protocol + "//" + window.location.host + `/project/${project.id}?tab=gc1dpp`;
-  const dppServiceUlid = useMemo(() => {
-    if (!traceDppData?.economicResource?.traceDpp) return undefined;
-    return extractDppServiceUlid(traceDppData.economicResource.traceDpp);
-  }, [traceDppData]);
-  const dppUlid = dppServiceUlid || project.metadata?.dpp;
+  // Use metadata.dpp for DPP ULID (traceDpp is fetched only on-demand when user clicks DPP tab)
+  const dppUlid = project.metadata?.dpp;
   const showDppQr = project.conformsTo?.name === "Product" && !!dppUlid;
 
   const contributionsCount = contributions?.proposals.edges.length || 0;

--- a/components/partials/resource/sidebar/TechnicalInfoCard.tsx
+++ b/components/partials/resource/sidebar/TechnicalInfoCard.tsx
@@ -14,7 +14,7 @@ const TechnicalInfoCard = () => {
   return (
     <Card sectioned>
       <Stack vertical spacing="loose">
-        <LoshImportedDate projectId={project.id!} />
+        <LoshImportedDate addedOn={undefined} />
         <Text as="h3" variant="headingMd">
           {t("Licenses")}
         </Text>

--- a/lib/QueryAndMutation.ts
+++ b/lib/QueryAndMutation.ts
@@ -507,48 +507,18 @@ export const FETCH_RESOURCES = gql`
           classifiedAs
           note
           metadata
-          okhv
-          repo
           images {
             hash
             name
             mimeType
           }
-          version
-          licensor
           license
           primaryAccountable {
             id
             name
-            note
             images {
-              bin
               mimeType
             }
-            primaryLocation {
-              name
-            }
-          }
-          custodian {
-            id
-            name
-            note
-          }
-          accountingQuantity {
-            hasUnit {
-              id
-              label
-              symbol
-            }
-            hasNumericalValue
-          }
-          onhandQuantity {
-            hasUnit {
-              id
-              label
-              symbol
-            }
-            hasNumericalValue
           }
         }
       }

--- a/lib/resourceImages.ts
+++ b/lib/resourceImages.ts
@@ -47,8 +47,8 @@ export function fileToIfile(file: File): IFile {
 
 export function getUserImage(user: Partial<PersonWithFileEssential>): string {
   const image = user.images?.[0];
-  if (image) return formatImageSrc(image.mimeType, image.bin);
-  else return "";
+  if (image?.bin) return formatImageSrc(image.mimeType, image.bin);
+  return "";
 }
 
 export function dataURLtoFile(bin: string, mimeType: string, filename: string): globalThis.File {


### PR DESCRIPTION
## Problem

Production GUI times out loading zenflows assets because:

### 1. Project detail page fires 5 expensive queries simultaneously
Each triggers a full event-chain DFS traversal in the zenflows backend:
- `GET_PROJECT_LAYOUT` with `trace` (FetchProjectLayout)
- `GET_TRACE` with `trace` (ProjectTime)
- `GET_PROJECT_TRACE` with `trace` (LoshImportedDate)
- `QUERY_TRACE_DPP` with `traceDpp` (ProjectTabs)
- `QUERY_TRACE_DPP` with `traceDpp` (ContributionsCard)

Backend detail: `trace` triggers `EconomicResource.Domain.trace/2` which does a depth-first search through the entire event chain. `traceDpp` is worse — `trace_dpp/2` recursively walks the trace graph with depth 100M, each recursion wrapped in `Repo.multi` DB transactions.

### 2. FETCH_RESOURCES fetches heavy unused fields per resource
- `primaryAccountable.images.bin` — base64 binary image data (HUGE payload)
- `custodian` — DB preload, never used in cards
- `accountingQuantity` / `onhandQuantity` — `Measure.preload` each, never used in cards
- `okhv`, `repo`, `version`, `licensor`, `primaryAccountable.note`, `primaryAccountable.primaryLocation` — unused strings

## Changes

- Remove `trace` from `GET_PROJECT_LAYOUT`
- Remove eager `QUERY_TRACE_DPP` from ProjectTabs & ContributionsCard, use `project.metadata?.dpp` fallback
- Remove `GET_TRACE` from ProjectTime (was dead code, never imported)
- Remove `GET_PROJECT_TRACE` from LoshImportedDate, simplify to optional prop
- Fix broken `e.trace?.filter(...)[0]` crash in ProjectsTableRow
- Slim `FETCH_RESOURCES`: removed 10 unused/heavy fields
- Make `getUserImage()` safe when `bin` is missing
- Matching `FETCH_RESOURCES` update in interfacer-client (already pushed)

## What's preserved
- `ProjectDpp.tsx` still fetches `traceDpp` lazily — only when user clicks the DPP tab
- `currentLocation` kept in `FETCH_RESOURCES` (used by maps and some cards)