### PR TITLE
UI parity with Figma prototype: sticky sidebars, creation forms, filters, product price/availability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ cypress.env.json
 *.db
 .beads-credential-key
 .beads/proxieddb/
+
+# Local build/screenshot artifacts
+.sw-build/

--- a/components/CatalogFilterSidebar.tsx
+++ b/components/CatalogFilterSidebar.tsx
@@ -1,7 +1,19 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright (C) 2022-2023 Dyne.org foundation <foundation@dyne.org>.
 
-import { Chemistry, Close, Cube, Flash, LocationStar, Recycle, Settings, Tag, Time, Tools } from "@carbon/icons-react";
+import {
+  Analytics,
+  Chemistry,
+  Close,
+  Cube,
+  Flash,
+  LocationStar,
+  Recycle,
+  Settings,
+  Tag,
+  Time,
+  Tools,
+} from "@carbon/icons-react";
 import { ScaleIcon } from "@heroicons/react/outline";
 import CheckboxFilter from "components/CheckboxFilter";
 import DualRangeSlider from "components/DualRangeSlider";
@@ -10,6 +22,8 @@ import ToggleSwitch from "components/ToggleSwitch";
 import { FetchLocation, fetchLocation, lookupLocation } from "lib/fetchLocation";
 import {
   AVAILABILITY_OPTIONS,
+  COMPLEXITY_LEVELS,
+  COMPLEXITY_PREFIX,
   MANUFACTURABLE_TRUE_TAG,
   POWER_COMPATIBILITY_OPTIONS,
   PRODUCT_CATEGORY_OPTIONS,
@@ -23,6 +37,8 @@ import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 export type CatalogVariant = "designs" | "products" | "services";
+
+const COMPLEXITY_LABELS = COMPLEXITY_LEVELS.map(l => l.label);
 
 interface CatalogFilterSidebarProps {
   variant: CatalogVariant;
@@ -215,6 +231,10 @@ export default function CatalogFilterSidebar({ variant, collapsed = false, onTog
     () => getSelectedItems(currentTags, TAG_PREFIX.POWER_COMPAT, POWER_COMPATIBILITY_OPTIONS),
     [currentTags]
   );
+  const selectedComplexity = useMemo(
+    () => getSelectedItems(currentTags, COMPLEXITY_PREFIX, COMPLEXITY_LABELS),
+    [currentTags]
+  );
   const repairInfo = useMemo(() => currentTags.includes(REPAIRABILITY_AVAILABLE_TAG), [currentTags]);
 
   // Toggle a tag in the URL
@@ -267,18 +287,21 @@ export default function CatalogFilterSidebar({ variant, collapsed = false, onTog
 
   return (
     <div
-      className="bg-ifr-surface border-r border-ifr h-full shrink-0 relative"
+      className="bg-ifr-surface border-r border-ifr shrink-0 relative sticky self-start"
       style={{
         width: collapsed ? "0px" : "var(--ifr-sidebar-width)",
         overflow: "hidden",
         transition: "width 250ms ease",
         borderRightWidth: collapsed ? "0px" : undefined,
+        top: "var(--ifr-topbar-height)",
+        maxHeight: "calc(100vh - var(--ifr-topbar-height))",
       }}
     >
       <div
-        className="h-full overflow-y-auto"
+        className="overflow-y-auto"
         style={{
           width: "var(--ifr-sidebar-width)",
+          maxHeight: "calc(100vh - var(--ifr-topbar-height))",
           opacity: collapsed ? 0 : 1,
           transition: "opacity 200ms ease",
           pointerEvents: collapsed ? "none" : undefined,
@@ -414,6 +437,18 @@ export default function CatalogFilterSidebar({ variant, collapsed = false, onTog
                   );
                 })}
               </div>
+            </FilterSection>
+
+            <FilterSection
+              icon={<Analytics size={16} />}
+              label="Complexity"
+              badge={selectedComplexity.length || undefined}
+            >
+              <CheckboxFilter
+                items={COMPLEXITY_LABELS}
+                selectedItems={selectedComplexity}
+                onToggle={toggleTag(COMPLEXITY_PREFIX)}
+              />
             </FilterSection>
           </>
         )}
@@ -617,8 +652,8 @@ export default function CatalogFilterSidebar({ variant, collapsed = false, onTog
 
         {/* Shared sections */}
 
-        {/* Location — designs and products only */}
-        {variant !== "services" && (
+        {/* Location — products and services (not designs) */}
+        {variant !== "designs" && (
           <FilterSection icon={<LocationStar size={16} />} label="Location" badge={hasActiveLocation ? 1 : undefined}>
             <div className="flex flex-col gap-2" ref={locationDropdownRef}>
               {locationLabel ? (

--- a/components/CatalogFilterSidebar.tsx
+++ b/components/CatalogFilterSidebar.tsx
@@ -32,6 +32,7 @@ import {
   TAG_PREFIX,
   slugifyTagValue,
 } from "lib/tagging";
+import { DESIGN_POWER_SOURCE_OPTIONS } from "components/partials/create/project/steps/PowerRequirementsStep";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -228,8 +229,13 @@ export default function CatalogFilterSidebar({ variant, collapsed = false, onTog
     [currentTags]
   );
   const selectedPower = useMemo(
-    () => getSelectedItems(currentTags, TAG_PREFIX.POWER_COMPAT, POWER_COMPATIBILITY_OPTIONS),
-    [currentTags]
+    () =>
+      getSelectedItems(
+        currentTags,
+        TAG_PREFIX.POWER_COMPAT,
+        variant === "designs" ? DESIGN_POWER_SOURCE_OPTIONS : POWER_COMPATIBILITY_OPTIONS
+      ),
+    [currentTags, variant]
   );
   const selectedComplexity = useMemo(
     () => getSelectedItems(currentTags, COMPLEXITY_PREFIX, COMPLEXITY_LABELS),
@@ -779,7 +785,7 @@ export default function CatalogFilterSidebar({ variant, collapsed = false, onTog
               badge={selectedPower.length || undefined}
             >
               <CheckboxFilter
-                items={[...POWER_COMPATIBILITY_OPTIONS]}
+                items={variant === "designs" ? [...DESIGN_POWER_SOURCE_OPTIONS] : [...POWER_COMPATIBILITY_OPTIONS]}
                 selectedItems={selectedPower}
                 onToggle={toggleTag(TAG_PREFIX.POWER_COMPAT)}
               />

--- a/components/CatalogLayout.tsx
+++ b/components/CatalogLayout.tsx
@@ -137,7 +137,7 @@ export default function CatalogLayout({
   };
 
   return (
-    <div className="flex flex-1 min-h-0 overflow-hidden">
+    <div className="flex flex-1 items-start">
       {/* Filter Sidebar */}
       <CatalogFilterSidebar
         variant={variant}

--- a/components/DetailSection.tsx
+++ b/components/DetailSection.tsx
@@ -10,6 +10,8 @@ interface DetailSectionProps {
   defaultOpen?: boolean;
   sectionId?: string;
   onOpen?: () => void;
+  /** When false the section body is always visible and the header does not collapse it. */
+  collapsible?: boolean;
   children: ReactNode;
 }
 
@@ -22,9 +24,10 @@ export default function DetailSection({
   defaultOpen = false,
   sectionId,
   onOpen,
+  collapsible = true,
   children,
 }: DetailSectionProps) {
-  const [open, setOpen] = useState(defaultOpen);
+  const [open, setOpen] = useState(collapsible ? defaultOpen : true);
 
   const handleOpenEvent = useCallback(
     (e: Event) => {
@@ -41,33 +44,45 @@ export default function DetailSection({
     return () => window.removeEventListener("open-section", handleOpenEvent);
   }, [handleOpenEvent]);
 
-  return (
-    <div id={sectionId} className="bg-ifr-surface border border-ifr rounded-ifr-md shadow-ifr-sm overflow-hidden">
-      <button
-        type="button"
-        onClick={() => {
-          if (!open) onOpen?.();
-          setOpen(!open);
-        }}
-        className="flex items-center w-full gap-4 p-6 text-left"
-        aria-expanded={open}
-        aria-controls={sectionId ? `${sectionId}-content` : undefined}
-      >
-        <div className={`flex items-center justify-center w-10 h-10 rounded-ifr-sm shrink-0 ${iconBg}`}>{icon}</div>
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2">
-            <h3 className="text-2xl font-bold" style={{ fontFamily: "var(--ifr-font-heading)" }}>
-              {title}
-            </h3>
-            {badge}
-          </div>
-          {subtitle && <p className="text-sm text-ifr-text-secondary mt-0.5">{subtitle}</p>}
+  const headerInner = (
+    <>
+      <div className={`flex items-center justify-center w-10 h-10 rounded-ifr-sm shrink-0 ${iconBg}`}>{icon}</div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <h3 className="text-2xl font-bold" style={{ fontFamily: "var(--ifr-font-heading)" }}>
+            {title}
+          </h3>
+          {badge}
         </div>
+        {subtitle && <p className="text-sm text-ifr-text-secondary mt-0.5">{subtitle}</p>}
+      </div>
+      {collapsible && (
         <ChevronDown
           size={20}
           className={`shrink-0 text-ifr-text-secondary transition-transform ${open ? "rotate-180" : ""}`}
         />
-      </button>
+      )}
+    </>
+  );
+
+  return (
+    <div id={sectionId} className="bg-ifr-surface border border-ifr rounded-ifr-md shadow-ifr-sm overflow-hidden">
+      {collapsible ? (
+        <button
+          type="button"
+          onClick={() => {
+            if (!open) onOpen?.();
+            setOpen(!open);
+          }}
+          className="flex items-center w-full gap-4 p-6 text-left"
+          aria-expanded={open}
+          aria-controls={sectionId ? `${sectionId}-content` : undefined}
+        >
+          {headerInner}
+        </button>
+      ) : (
+        <div className="flex items-center w-full gap-4 p-6 text-left">{headerInner}</div>
+      )}
       {open && (
         <>
           <div className="border-t border-ifr mx-6" />

--- a/components/MachineDrawer.tsx
+++ b/components/MachineDrawer.tsx
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2022-2023 Dyne.org foundation <foundation@dyne.org>.
+
+import { Close, Upload } from "@carbon/icons-react";
+import { useAuth } from "hooks/useAuth";
+import devLog from "lib/devLog";
+import { useTranslation } from "next-i18next";
+import { useEffect, useRef, useState } from "react";
+
+const MACHINE_TYPES = [
+  "3D Printer",
+  "CNC Mill",
+  "Laser Cutter",
+  "PCB Mill",
+  "Vinyl Cutter",
+  "Embroidery Machine",
+  "Soldering Iron",
+  "Router",
+  "Drill Press",
+  "Band Saw",
+  "Lathe",
+  "Waterjet Cutter",
+];
+
+interface MachineDrawerProps {
+  open: boolean;
+  onClose: () => void;
+  onCreated?: () => void;
+}
+
+/** Right-hand collapsible drawer to quickly add machines, matching the DTEC prototype. */
+export default function MachineDrawer({ open, onClose, onCreated }: MachineDrawerProps) {
+  const { t } = useTranslation("common");
+  const { user, client } = useAuth();
+
+  const [name, setName] = useState("");
+  const [type, setType] = useState("");
+  const [location, setLocation] = useState("");
+  const [description, setDescription] = useState("");
+  const [imageFile, setImageFile] = useState<File | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  // Reset when the drawer opens
+  useEffect(() => {
+    if (open) {
+      setName("");
+      setType("");
+      setLocation("");
+      setDescription("");
+      setImageFile(null);
+      setFeedback(null);
+    }
+  }, [open]);
+
+  const isValid = name.trim().length > 0 && type.trim().length > 0;
+
+  async function uploadImage(): Promise<string | undefined> {
+    if (!imageFile || !client?.config.dppUrl) return undefined;
+    try {
+      const attachment = await client.files.uploadToDpp(imageFile);
+      return `${client.config.dppUrl}/file/${encodeURIComponent(attachment.id)}`;
+    } catch (e) {
+      devLog("Machine image upload failed", e);
+      return undefined;
+    }
+  }
+
+  async function save(): Promise<boolean> {
+    if (!client || !user || !isValid) return false;
+    setSaving(true);
+    try {
+      const imageUrl = await uploadImage();
+      await client.resources.createMachine({
+        name: name.trim(),
+        type: type || undefined,
+        location: location.trim() || undefined,
+        note: description.trim(),
+        image: imageUrl,
+        metadata: { remote: false },
+      });
+      onCreated?.();
+      return true;
+    } catch (e) {
+      devLog("Machine creation failed", e);
+      setFeedback(t("Could not save the machine. Please try again."));
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleSaveAndAddAnother() {
+    const ok = await save();
+    if (ok) {
+      setName("");
+      setType("");
+      setLocation("");
+      setDescription("");
+      setImageFile(null);
+      setFeedback(t("Machine saved. Add another."));
+    }
+  }
+
+  async function handleDone() {
+    if (isValid) {
+      const ok = await save();
+      if (!ok) return;
+    }
+    onClose();
+  }
+
+  if (!open) return null;
+
+  const labelStyle = {
+    fontFamily: "var(--ifr-font-body)",
+    fontSize: "var(--ifr-fs-sm)",
+    fontWeight: "var(--ifr-fw-semibold)" as const,
+    color: "var(--ifr-text-primary)",
+  };
+  const inputStyle = {
+    height: "var(--ifr-control-height)",
+    fontFamily: "var(--ifr-font-body)",
+    fontSize: "var(--ifr-fs-base)",
+  };
+  const optionalLabel = `(${t("optional")})`;
+
+  return (
+    <div className="fixed inset-0 z-[60]">
+      {/* Overlay */}
+      <div className="absolute inset-0 bg-black/40" onClick={onClose} />
+
+      {/* Drawer */}
+      <div
+        className="absolute right-0 top-0 h-full bg-ifr-surface shadow-lg flex flex-col"
+        style={{ width: "min(420px, 100vw)", borderLeft: "1px solid var(--ifr-border)" }}
+      >
+        {/* Header */}
+        <div className="flex items-start justify-between gap-3 px-6 py-5 border-b border-ifr">
+          <div>
+            <h3
+              className="text-ifr-text-primary m-0"
+              style={{
+                fontFamily: "var(--ifr-font-heading)",
+                fontSize: "var(--ifr-fs-lg)",
+                fontWeight: "var(--ifr-fw-bold)",
+              }}
+            >
+              {t("Add machines")}
+            </h3>
+            <p
+              className="text-ifr-text-secondary m-0 mt-1"
+              style={{ fontFamily: "var(--ifr-font-body)", fontSize: "var(--ifr-fs-sm)" }}
+            >
+              {t("Save and keep adding — the form resets automatically")}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={t("Close")}
+            className="bg-transparent border-none p-1 cursor-pointer text-ifr-text-secondary hover:text-ifr-text-primary"
+          >
+            <Close size={18} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-6 py-5 flex flex-col gap-5">
+          <div className="flex flex-col gap-1.5">
+            <label style={labelStyle}>
+              {t("Machine name")} <span style={{ color: "var(--ifr-green)" }}>*</span>
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              placeholder={t("e.g. Prusa i3 MK3S+")}
+              className="w-full px-3 bg-ifr-form-input border border-ifr-form-input rounded-ifr-sm outline-none focus:border-ifr-green"
+              style={inputStyle}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label style={labelStyle}>
+              {t("Type")} <span style={{ color: "var(--ifr-green)" }}>*</span>
+            </label>
+            <select
+              value={type}
+              onChange={e => setType(e.target.value)}
+              className="w-full px-3 bg-ifr-form-input border border-ifr-form-input rounded-ifr-sm outline-none focus:border-ifr-green"
+              style={inputStyle}
+            >
+              <option value="">{t("Select a type…")}</option>
+              {MACHINE_TYPES.map(m => (
+                <option key={m} value={m}>
+                  {m}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label style={labelStyle}>
+              {t("Location")}{" "}
+              <span className="text-ifr-text-secondary" style={{ fontWeight: 400 }}>
+                {optionalLabel}
+              </span>
+            </label>
+            <input
+              type="text"
+              value={location}
+              onChange={e => setLocation(e.target.value)}
+              placeholder={t("e.g. FabLab Barcelona")}
+              className="w-full px-3 bg-ifr-form-input border border-ifr-form-input rounded-ifr-sm outline-none focus:border-ifr-green"
+              style={inputStyle}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label style={labelStyle}>
+              {t("Short description")}{" "}
+              <span className="text-ifr-text-secondary" style={{ fontWeight: 400 }}>
+                {optionalLabel}
+              </span>
+            </label>
+            <textarea
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              placeholder={t("Briefly describe the machine, its specs or intended use…")}
+              rows={4}
+              className="w-full px-3 py-2 bg-ifr-form-input border border-ifr-form-input rounded-ifr-sm outline-none focus:border-ifr-green resize-y"
+              style={{ fontFamily: "var(--ifr-font-body)", fontSize: "var(--ifr-fs-base)" }}
+            />
+            <p className="text-ifr-text-secondary m-0" style={{ fontSize: "var(--ifr-fs-xs)" }}>
+              {t("This will appear in machine listings and service descriptions.")}
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label style={labelStyle}>
+              {t("Image")}{" "}
+              <span className="text-ifr-text-secondary" style={{ fontWeight: 400 }}>
+                {optionalLabel}
+              </span>
+            </label>
+            <input
+              ref={fileRef}
+              type="file"
+              accept="image/*"
+              className="hidden"
+              onChange={e => setImageFile(e.target.files?.[0] || null)}
+            />
+            <button
+              type="button"
+              onClick={() => fileRef.current?.click()}
+              className="flex items-center gap-2 px-3 py-2 border border-dashed border-ifr rounded-ifr-sm cursor-pointer hover:bg-ifr-hover transition-colors text-ifr-text-secondary"
+              style={{ fontFamily: "var(--ifr-font-body)", fontSize: "var(--ifr-fs-sm)" }}
+            >
+              <Upload size={16} />
+              {imageFile ? imageFile.name : t("Click to upload or drag & drop PNG, JPG, WEBP — max 10 MB")}
+            </button>
+          </div>
+
+          {feedback && (
+            <p
+              className="m-0"
+              style={{ fontFamily: "var(--ifr-font-body)", fontSize: "var(--ifr-fs-sm)", color: "var(--ifr-green)" }}
+            >
+              {feedback}
+            </p>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-4 border-t border-ifr flex items-center gap-3">
+          <button
+            type="button"
+            disabled={!isValid || saving}
+            onClick={handleSaveAndAddAnother}
+            className={`flex-1 px-4 py-2.5 border-none transition-opacity ${
+              isValid && !saving ? "cursor-pointer hover:opacity-90" : "opacity-50 cursor-not-allowed"
+            }`}
+            style={{
+              borderRadius: "var(--ifr-radius-sm)",
+              backgroundColor: "var(--ifr-yellow)",
+              fontFamily: "var(--ifr-font-body)",
+              fontSize: "var(--ifr-fs-base)",
+              fontWeight: "var(--ifr-fw-medium)",
+              color: "var(--ifr-text-primary)",
+            }}
+          >
+            {saving ? t("Saving…") : t("Save & add another")}
+          </button>
+          <button
+            type="button"
+            disabled={saving}
+            onClick={handleDone}
+            className="px-4 py-2.5 bg-transparent border border-ifr rounded-ifr-sm cursor-pointer hover:bg-ifr-hover transition-colors"
+            style={{
+              fontFamily: "var(--ifr-font-body)",
+              fontSize: "var(--ifr-fs-base)",
+              fontWeight: "var(--ifr-fw-medium)",
+              color: "var(--ifr-text-primary)",
+            }}
+          >
+            {t("Done")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/ProfilePageNew.tsx
+++ b/components/ProfilePageNew.tsx
@@ -18,6 +18,7 @@ import {
 import { ExternalLinkIcon, LocationMarkerIcon } from "@heroicons/react/outline";
 import BrUserAvatar from "components/brickroom/BrUserAvatar";
 import EntityTypeIcon from "components/EntityTypeIcon";
+import MachineDrawer from "components/MachineDrawer";
 import { useUser } from "components/layout/FetchUserLayout";
 import ProjectCardNew from "components/ProjectCardNew";
 import { ProjectType } from "components/types";
@@ -187,9 +188,11 @@ function ProfileTabContent({
               </p>
             </div>
             <div className="flex items-center gap-3">
-              <Link href={ctaConfig.createUrl}>
-                <a
-                  className="flex items-center gap-2 px-4 no-underline transition-colors hover:opacity-90"
+              {tabType === ProjectType.MACHINE ? (
+                <button
+                  type="button"
+                  onClick={() => window.dispatchEvent(new CustomEvent("open-machine-drawer"))}
+                  className="flex items-center gap-2 px-4 border-none cursor-pointer transition-colors hover:opacity-90"
                   style={{
                     height: "var(--ifr-control-height)",
                     borderRadius: "var(--ifr-radius-sm)",
@@ -202,8 +205,26 @@ function ProfileTabContent({
                 >
                   {t(ctaConfig.createLabel)}
                   <ArrowRight size={16} />
-                </a>
-              </Link>
+                </button>
+              ) : (
+                <Link href={ctaConfig.createUrl}>
+                  <a
+                    className="flex items-center gap-2 px-4 no-underline transition-colors hover:opacity-90"
+                    style={{
+                      height: "var(--ifr-control-height)",
+                      borderRadius: "var(--ifr-radius-sm)",
+                      backgroundColor: "var(--ifr-yellow)",
+                      fontFamily: "var(--ifr-font-body)",
+                      fontSize: "var(--ifr-fs-base)",
+                      fontWeight: "var(--ifr-fw-medium)",
+                      color: "var(--ifr-text-primary)",
+                    }}
+                  >
+                    {t(ctaConfig.createLabel)}
+                    <ArrowRight size={16} />
+                  </a>
+                </Link>
+              )}
             </div>
           </div>
         </div>
@@ -1044,6 +1065,14 @@ export default function ProfilePageNew() {
 
   const isOwner = user?.ulid === id;
 
+  // Machine creation drawer
+  const [machineDrawerOpen, setMachineDrawerOpen] = useState(false);
+  useEffect(() => {
+    const open = () => setMachineDrawerOpen(true);
+    window.addEventListener("open-machine-drawer", open);
+    return () => window.removeEventListener("open-machine-drawer", open);
+  }, []);
+
   // Tab state from URL
   const tabParam = (router.query.tab as string) || "designs";
   const activeTab: ProfileTabId = (
@@ -1281,6 +1310,8 @@ export default function ProfilePageNew() {
           />
         )}
       </div>
+
+      <MachineDrawer open={machineDrawerOpen} onClose={() => setMachineDrawerOpen(false)} />
     </div>
   );
 }

--- a/components/ProjectCardImage.tsx
+++ b/components/ProjectCardImage.tsx
@@ -34,7 +34,7 @@ const ProjectImage = (props: Props) => {
   };
 
   return (
-    <div className="h-60 bg-base-200 flex items-center justify-center overflow-hidden">
+    <div className="h-full w-full bg-base-200 flex items-center justify-center overflow-hidden">
       {(!image || error) && (
         <div className="opacity-40">
           <ProjectTypeRoundIcon projectType={projectType} />

--- a/components/ProjectDetailNew.tsx
+++ b/components/ProjectDetailNew.tsx
@@ -28,7 +28,7 @@ import { useTranslation } from "next-i18next";
 import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { ReactNode, useEffect, useMemo, useState } from "react";
+import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import ReviewSection from "./ReviewSection";
 import useFeedbackApi, { type ReviewSummary } from "lib/feedback";
 import StepModelViewer from "./StepModelViewer";
@@ -91,16 +91,33 @@ function ProjectSidebarNew({ project, projectType, sidebarRating }: ProjectSideb
     : undefined;
 
   return (
-    <div className="w-full lg:w-[300px] shrink-0">
+    <div className="w-full lg:w-[300px] shrink-0 h-full">
       <div
         className="sticky flex flex-col"
         style={{
-          top: "calc(var(--ifr-topbar-height) + 80px)",
+          top: "calc(var(--ifr-topbar-height) + 16px)",
           border: "1px solid #c9cccf",
           borderRadius: "4px",
           backgroundColor: "#fff",
+          maxHeight: "calc(100vh - var(--ifr-topbar-height) - 32px)",
+          overflowY: "auto",
         }}
       >
+        {/* Title */}
+        <div className="px-4 pt-4">
+          <h2
+            className="text-ifr-text-primary m-0"
+            style={{
+              fontFamily: "var(--ifr-font-heading)",
+              fontSize: "var(--ifr-fs-lg)",
+              fontWeight: "var(--ifr-fw-bold)",
+              lineHeight: "1.3",
+            }}
+          >
+            {project.name}
+          </h2>
+        </div>
+
         {/* Price & CTA section */}
         <div className="flex flex-col gap-6 px-4 pt-4 pb-6">
           {/* Product: Price & Availability */}
@@ -595,6 +612,50 @@ function ImageGallery({ images }: { images: string[] }) {
             </button>
           ))}
         </div>
+      )}
+    </div>
+  );
+}
+
+/** Markdown body that clamps to a fixed height with a Read more / Show less toggle. */
+function ReadMoreMarkdown({ html }: { html: string }) {
+  const { t } = useTranslation("common");
+  const ref = useRef<HTMLDivElement>(null);
+  const [overflowing, setOverflowing] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const CLAMP_PX = 220;
+
+  useEffect(() => {
+    if (ref.current) setOverflowing(ref.current.scrollHeight > CLAMP_PX + 20);
+  }, [html]);
+
+  return (
+    <div>
+      <div
+        ref={ref}
+        className="prose max-w-none text-ifr-text-primary"
+        style={{
+          fontFamily: "var(--ifr-font-body)",
+          fontSize: "var(--ifr-fs-md)",
+          maxHeight: expanded ? undefined : CLAMP_PX,
+          overflow: expanded ? undefined : "hidden",
+        }}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+      {overflowing && (
+        <button
+          type="button"
+          onClick={() => setExpanded(v => !v)}
+          className="mt-2 bg-transparent border-none p-0 cursor-pointer hover:underline"
+          style={{
+            color: "var(--ifr-green)",
+            fontFamily: "var(--ifr-font-body)",
+            fontSize: "var(--ifr-fs-sm)",
+            fontWeight: "var(--ifr-fw-medium)",
+          }}
+        >
+          {expanded ? t("Show less") : t("Read more")}
+        </button>
       )}
     </div>
   );
@@ -1369,7 +1430,7 @@ export default function ProjectDetailNew() {
 
   return (
     <div className="flex-1 bg-ifr-page" style={{ fontFamily: "var(--ifr-font-body)" }}>
-      <div className="max-w-[1280px] mx-auto px-6 py-8 flex gap-8 items-start">
+      <div className="max-w-[1280px] mx-auto px-6 py-8 flex gap-8">
         {/* Main content */}
         <div className="flex-1 min-w-0 flex flex-col gap-4">
           {/* Breadcrumb */}
@@ -1604,17 +1665,11 @@ export default function ProjectDetailNew() {
               iconBg="bg-ifr-hover"
               title={t("Overview")}
               subtitle={t("Description and key features")}
-              defaultOpen
+              collapsible={false}
               sectionId="overview"
             >
               <div className="flex flex-col gap-6">
-                {project.note && (
-                  <div
-                    className="prose max-w-none text-ifr-text-primary"
-                    style={{ fontFamily: "var(--ifr-font-body)", fontSize: "var(--ifr-fs-md)" }}
-                    dangerouslySetInnerHTML={{ __html: MdParser.render(project.note) }}
-                  />
-                )}
+                {project.note && <ReadMoreMarkdown html={MdParser.render(project.note)} />}
 
                 {/* Tags */}
                 {tags.length > 0 && (

--- a/components/ProjectsCards.tsx
+++ b/components/ProjectsCards.tsx
@@ -34,6 +34,7 @@ import ProductCardSkeleton from "./ProductCardSkeleton";
 // import ProjectDisplay from "./ProjectDisplay";
 import { useTranslation } from "next-i18next";
 import dynamic from "next/dynamic";
+import { Checkmark, Launch } from "@carbon/icons-react";
 import ProjectCardFigma from "./ProjectCardFigma";
 
 const CardsGroup = dynamic(() => import("./CardsGroup"), { ssr: false });
@@ -50,66 +51,97 @@ function miniType(project: Partial<EconomicResource>): ProjectType {
   return ProjectType.DESIGN;
 }
 
-const miniTypeColor: Record<string, string> = {
-  [ProjectType.DESIGN]: "var(--ifr-green)",
-  [ProjectType.PRODUCT]: "var(--ifr-type-product)",
-  [ProjectType.SERVICE]: "var(--ifr-type-service)",
-  [ProjectType.DPP]: "var(--ifr-type-dpp)",
-  [ProjectType.MACHINE]: "var(--ifr-type-product)",
-};
-
 /** Compact horizontal card used for "Included Projects" / related lists. */
 function TinyProjectCard({ project }: { project: Partial<EconomicResource> }) {
+  const { t } = useTranslation("common");
   const type = miniType(project);
   const src = findProjectImages(project)?.[0];
+  const author = project.primaryAccountable?.name;
+  const capType = type.charAt(0).toUpperCase() + type.slice(1);
+  const viewLabel = `${t("View")} ${capType}`;
   return (
     <div
-      className="flex items-center gap-3 p-3 bg-ifr-surface border border-ifr hover:bg-ifr-hover transition-colors"
-      style={{ borderRadius: "var(--ifr-radius-md)" }}
+      className="w-full flex cursor-pointer transition-colors duration-150 hover:bg-ifr-hover overflow-hidden"
+      style={{ borderRadius: "var(--ifr-radius-md)", border: "1px solid var(--ifr-border)", height: 104 }}
     >
       <div
-        className="shrink-0 overflow-hidden flex items-center justify-center bg-base-200"
-        style={{ width: 56, height: 56, borderRadius: "var(--ifr-radius-sm)" }}
+        className="shrink-0 overflow-hidden bg-ifr-surface flex items-center justify-center"
+        style={{ width: 104, height: "100%" }}
       >
         {src ? (
-          <img src={src} alt="" className="w-full h-full object-cover" />
+          <img src={src} alt={project.name || ""} className="w-full h-full object-cover" />
         ) : (
           <EntityTypeIcon type={type} size="default" fill="var(--ifr-green)" />
         )}
       </div>
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2">
-          <p
-            className="text-ifr-text-primary m-0 truncate"
+      <div className="flex flex-col gap-[8px] flex-1 min-w-0 px-[14px] py-[12px] justify-between">
+        <div className="flex flex-col gap-[4px] flex-1 min-w-0">
+          <div className="flex items-center gap-[8px]">
+            <span
+              className="text-ifr-text-primary truncate"
+              style={{
+                fontFamily: "var(--ifr-font-body)",
+                fontSize: "var(--ifr-fs-md)",
+                fontWeight: "var(--ifr-fw-medium)",
+                lineHeight: "24px",
+              }}
+            >
+              {project.name}
+            </span>
+            <span
+              className="shrink-0 flex items-center justify-center"
+              style={{
+                width: 22,
+                height: 22,
+                borderRadius: "var(--ifr-radius-sm)",
+                backgroundColor: "var(--ifr-green)",
+              }}
+            >
+              <Checkmark size={12} fill="#fff" style={{ display: "block", flexShrink: 0 }} />
+            </span>
+          </div>
+          {author && (
+            <div className="flex items-center gap-[8px]">
+              <span
+                className="text-ifr-text-secondary truncate"
+                style={{
+                  fontFamily: "var(--ifr-font-body)",
+                  fontSize: "var(--ifr-fs-base)",
+                  fontWeight: "var(--ifr-fw-regular)",
+                  lineHeight: "21px",
+                }}
+              >
+                {`@${author}`}
+              </span>
+            </div>
+          )}
+        </div>
+        <div className="flex items-center justify-between">
+          <span
+            className="text-ifr-text-secondary truncate"
             style={{
               fontFamily: "var(--ifr-font-body)",
-              fontSize: "var(--ifr-fs-md)",
-              fontWeight: "var(--ifr-fw-semibold)",
+              fontSize: "var(--ifr-fs-sm)",
+              fontWeight: "var(--ifr-fw-regular)",
+              lineHeight: "18px",
             }}
           >
-            {project.name}
-          </p>
+            {project.id}
+          </span>
           <span
-            className="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 text-white"
+            className="flex items-center gap-[4px] shrink-0"
             style={{
-              borderRadius: "var(--ifr-radius-sm)",
-              backgroundColor: miniTypeColor[type],
-              fontSize: "var(--ifr-fs-xs)",
-              fontWeight: "var(--ifr-fw-semibold)",
+              fontFamily: "var(--ifr-font-body)",
+              fontSize: "var(--ifr-fs-base)",
+              fontWeight: "var(--ifr-fw-medium)",
+              lineHeight: "21px",
+              color: "var(--ifr-green)",
             }}
           >
-            <EntityTypeIcon type={type} size="small" fill="#fff" />
-            {type}
+            {viewLabel}
+            <Launch size={14} style={{ color: "var(--ifr-green)" }} />
           </span>
         </div>
-        {project.note && (
-          <p
-            className="text-ifr-text-secondary m-0 truncate"
-            style={{ fontFamily: "var(--ifr-font-body)", fontSize: "var(--ifr-fs-sm)" }}
-          >
-            {project.note}
-          </p>
-        )}
       </div>
     </div>
   );

--- a/components/ProjectsCards.tsx
+++ b/components/ProjectsCards.tsx
@@ -25,16 +25,95 @@ import { EconomicResource, EconomicResourceFilterParams, FetchInventoryQuery } f
 // import DraftCard from "./DraftCard";
 import Link from "next/link";
 import EmptyState from "./EmptyState";
+import EntityTypeIcon from "./EntityTypeIcon";
 import LoshCard from "./LoshCard";
+import findProjectImages from "lib/findProjectImages";
+import { isProjectType } from "lib/isProjectType";
+import { ProjectType } from "./types";
 import ProductCardSkeleton from "./ProductCardSkeleton";
 // import ProjectDisplay from "./ProjectDisplay";
 import { useTranslation } from "next-i18next";
 import dynamic from "next/dynamic";
 import ProjectCardFigma from "./ProjectCardFigma";
 
-const ProjectDisplay = dynamic(() => import("./ProjectDisplay"), { ssr: false });
 const CardsGroup = dynamic(() => import("./CardsGroup"), { ssr: false });
 const DraftCard = dynamic(() => import("./DraftCard"), { ssr: false });
+
+function miniType(project: Partial<EconomicResource>): ProjectType {
+  const name = project.conformsTo?.name;
+  if (!name) return ProjectType.DESIGN;
+  const check = isProjectType(name);
+  if (check[ProjectType.PRODUCT]) return ProjectType.PRODUCT;
+  if (check[ProjectType.SERVICE]) return ProjectType.SERVICE;
+  if (check[ProjectType.DPP]) return ProjectType.DPP;
+  if (check[ProjectType.MACHINE]) return ProjectType.MACHINE;
+  return ProjectType.DESIGN;
+}
+
+const miniTypeColor: Record<string, string> = {
+  [ProjectType.DESIGN]: "var(--ifr-green)",
+  [ProjectType.PRODUCT]: "var(--ifr-type-product)",
+  [ProjectType.SERVICE]: "var(--ifr-type-service)",
+  [ProjectType.DPP]: "var(--ifr-type-dpp)",
+  [ProjectType.MACHINE]: "var(--ifr-type-product)",
+};
+
+/** Compact horizontal card used for "Included Projects" / related lists. */
+function TinyProjectCard({ project }: { project: Partial<EconomicResource> }) {
+  const type = miniType(project);
+  const src = findProjectImages(project)?.[0];
+  return (
+    <div
+      className="flex items-center gap-3 p-3 bg-ifr-surface border border-ifr hover:bg-ifr-hover transition-colors"
+      style={{ borderRadius: "var(--ifr-radius-md)" }}
+    >
+      <div
+        className="shrink-0 overflow-hidden flex items-center justify-center bg-base-200"
+        style={{ width: 56, height: 56, borderRadius: "var(--ifr-radius-sm)" }}
+      >
+        {src ? (
+          <img src={src} alt="" className="w-full h-full object-cover" />
+        ) : (
+          <EntityTypeIcon type={type} size="default" fill="var(--ifr-green)" />
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <p
+            className="text-ifr-text-primary m-0 truncate"
+            style={{
+              fontFamily: "var(--ifr-font-body)",
+              fontSize: "var(--ifr-fs-md)",
+              fontWeight: "var(--ifr-fw-semibold)",
+            }}
+          >
+            {project.name}
+          </p>
+          <span
+            className="shrink-0 inline-flex items-center gap-1 px-1.5 py-0.5 text-white"
+            style={{
+              borderRadius: "var(--ifr-radius-sm)",
+              backgroundColor: miniTypeColor[type],
+              fontSize: "var(--ifr-fs-xs)",
+              fontWeight: "var(--ifr-fw-semibold)",
+            }}
+          >
+            <EntityTypeIcon type={type} size="small" fill="#fff" />
+            {type}
+          </span>
+        </div>
+        {project.note && (
+          <p
+            className="text-ifr-text-secondary m-0 truncate"
+            style={{ fontFamily: "var(--ifr-font-body)", fontSize: "var(--ifr-fs-sm)" }}
+          >
+            {project.note}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
 
 export enum CardType {
   PROJECT = "project",
@@ -167,16 +246,17 @@ const ProjectsCards = (props: ProjectsCardsProps) => {
           {projects?.map(({ node }: { node: EconomicResource }) => distinguishProjects(node))}
         </CardsGroup>
       )}
-      {tiny &&
-        projects?.map(({ node }: { node: EconomicResource }) => (
-          <div className="py-2 hover:bg-base-300" key={node.id}>
-            <Link href={`/project/${node.id}`}>
-              <a>
-                <ProjectDisplay project={node} />
+      {tiny && (
+        <div className="flex flex-col gap-3">
+          {projects?.map(({ node }: { node: EconomicResource }) => (
+            <Link href={`/project/${node.id}`} key={node.id}>
+              <a className="block no-underline">
+                <TinyProjectCard project={node} />
               </a>
             </Link>
-          </div>
-        ))}
+          ))}
+        </div>
+      )}
       {type === CardType.DRAFT && !tiny && drafts && (
         <CardsGroup
           onLoadMore={loadMore}

--- a/components/partials/create/project/CreateProjectForm.tsx
+++ b/components/partials/create/project/CreateProjectForm.tsx
@@ -225,13 +225,13 @@ export default function CreateProjectForm(props: Props) {
       <ProjectTypeContext.Provider value={projectType}>
         <form onSubmit={handleSubmit(onSubmit)}>
           <div className="flex flex-col min-h-screen bg-ifr-page" style={{ fontFamily: "var(--ifr-font-body)" }}>
-            <div className="flex-1 flex flex-row justify-center gap-8 lg:gap-12 p-6 max-w-[1280px] mx-auto w-full">
-              <div className="hidden lg:block w-[260px] shrink-0">
+            <div className="flex-1 flex flex-row justify-center gap-8 lg:gap-12 p-6 lg:p-10 max-w-[1440px] mx-auto w-full">
+              <div className="hidden lg:block w-[300px] shrink-0">
                 <div className="sticky top-24">
                   <CreateProjectNav projectType={projectType} />
                 </div>
               </div>
-              <div className="flex-1 max-w-2xl pb-24">
+              <div className="flex-1 min-w-0 pb-24">
                 <CreateProjectFields projectType={projectType} onSubmit={onSubmit} />
               </div>
             </div>

--- a/components/partials/create/project/CreateProjectForm.tsx
+++ b/components/partials/create/project/CreateProjectForm.tsx
@@ -42,6 +42,11 @@ import * as yup from "yup";
 import { machinesStepDefaultValues, machinesStepSchema, MachinesStepValues } from "./steps/MachinesStep.schema";
 import { materialsStepDefaultValues, materialsStepSchema, MaterialsStepValues } from "./steps/MaterialsStep.schema";
 import {
+  powerRequirementsStepDefaultValues,
+  powerRequirementsStepSchema,
+  PowerRequirementsStepValues,
+} from "./steps/PowerRequirementsStep.schema";
+import {
   productFiltersStepDefaultValues,
   productFiltersStepSchema,
   ProductFiltersStepValues,
@@ -79,6 +84,7 @@ export interface CreateProjectValues {
   licenses: LicenseStepValues;
   machines: MachinesStepValues;
   materials: MaterialsStepValues;
+  power: PowerRequirementsStepValues;
 }
 
 export const createProjectDefaultValues: CreateProjectValues = {
@@ -95,6 +101,7 @@ export const createProjectDefaultValues: CreateProjectValues = {
   licenses: licenseStepDefaultValues,
   machines: machinesStepDefaultValues,
   materials: materialsStepDefaultValues,
+  power: powerRequirementsStepDefaultValues,
 };
 
 export const createProjectSchema = () =>
@@ -121,6 +128,7 @@ export const createProjectSchema = () =>
     licenses: licenseStepSchema(),
     machines: machinesStepSchema(),
     materials: materialsStepSchema(),
+    power: powerRequirementsStepSchema(),
   });
 
 export type CreateProjectSchemaContext = LocationStepSchemaContext;
@@ -166,6 +174,7 @@ export default function CreateProjectForm(props: Props) {
     licenses: licenseStepDefaultValues,
     machines: machinesStepDefaultValues,
     materials: materialsStepDefaultValues,
+    power: powerRequirementsStepDefaultValues,
   };
 
   useEffect(() => {

--- a/components/partials/create/project/parts/CreateProjectFields.tsx
+++ b/components/partials/create/project/parts/CreateProjectFields.tsx
@@ -32,9 +32,9 @@ export default function CreateProjectFields(props: Props) {
       ),
     },
     [ProjectType.DESIGN]: {
-      title: t("Add a design"),
+      title: t("Add a new project to Interfacer"),
       subtitle: t(
-        "Import your project repository. Share your open source hardware project documentation and collaborate on building it. Your contribution will help others learn and build upon your work."
+        "Add all the info needed about your project. Add purchase information (if available), and specify the location where your product is available. Create a Digital Product Passport for your product."
       ),
     },
     [ProjectType.MACHINE]: {
@@ -57,15 +57,15 @@ export default function CreateProjectFields(props: Props) {
 
   return (
     <div className="flex flex-col gap-6">
-      {/* Header card */}
-      <div className="bg-ifr-surface border border-ifr rounded-ifr-md py-8 px-8">
+      {/* Header (borderless, prototype typography) */}
+      <div className="pt-2 pb-2">
         <h1
-          className="text-ifr-text-primary m-0 mb-2"
+          className="text-ifr-text-primary m-0 mb-3"
           style={{
             fontFamily: "var(--ifr-font-heading)",
-            fontSize: "var(--ifr-fs-2xl)",
+            fontSize: "var(--ifr-fs-xl)",
             fontWeight: "var(--ifr-fw-bold)",
-            lineHeight: "1.2",
+            lineHeight: "1.5",
           }}
         >
           {titles[projectType].title}
@@ -74,8 +74,9 @@ export default function CreateProjectFields(props: Props) {
           className="text-ifr-text-secondary m-0"
           style={{
             fontFamily: "var(--ifr-font-body)",
-            fontSize: "var(--ifr-fs-md)",
-            lineHeight: "1.6",
+            fontSize: "var(--ifr-fs-base)",
+            lineHeight: "1.5",
+            maxWidth: "720px",
           }}
         >
           {titles[projectType].subtitle}

--- a/components/partials/create/project/parts/CreateProjectNav.tsx
+++ b/components/partials/create/project/parts/CreateProjectNav.tsx
@@ -43,19 +43,11 @@ export default function CreateProjectNav(props: Props) {
   }, []);
 
   return (
-    <nav className="bg-ifr-surface border border-ifr rounded-ifr-md p-4 flex flex-col gap-1" aria-label={t("Sections")}>
-      <p
-        className="text-ifr-text-secondary m-0 mb-2 px-3"
-        style={{
-          fontFamily: "var(--ifr-font-body)",
-          fontSize: "var(--ifr-fs-sm)",
-          fontWeight: "var(--ifr-fw-semibold)",
-          textTransform: "uppercase",
-          letterSpacing: "0.05em",
-        }}
-      >
-        {t("Sections")}
-      </p>
+    <nav
+      className="bg-ifr-surface border border-ifr flex flex-col gap-2"
+      style={{ borderRadius: "var(--ifr-radius-md)", padding: "24px" }}
+      aria-label={t("Sections")}
+    >
       {sections.map(section => {
         const isActive = activeId === section.id;
         const isRequired = section.required?.includes(projectType);
@@ -65,19 +57,17 @@ export default function CreateProjectNav(props: Props) {
             key={section.id}
             type="button"
             onClick={() => scrollTo(section.id)}
-            className={`text-left px-3 py-2 border-none cursor-pointer transition-colors rounded-sm ${
-              isActive ? "bg-ifr-hover" : "bg-transparent hover:bg-ifr-hover/50"
-            }`}
+            className="text-left border-none cursor-pointer transition-colors bg-transparent hover:opacity-70"
             style={{
               fontFamily: "var(--ifr-font-body)",
               fontSize: "var(--ifr-fs-base)",
               fontWeight: isActive ? "var(--ifr-fw-semibold)" : "var(--ifr-fw-medium)",
-              color: isActive ? "var(--ifr-text-primary)" : "var(--ifr-text-secondary)",
-              borderRadius: "var(--ifr-radius-sm)",
+              color: "var(--ifr-text-primary)",
+              padding: "4px 0",
             }}
           >
-            {section.navLabel}
-            {isRequired && <span style={{ color: "var(--ifr-green)" }}>{" *"}</span>}
+            {section.navLabelByType?.[projectType] || section.navLabel}
+            {isRequired && <span style={{ color: "var(--ifr-red)" }}>{" *"}</span>}
           </button>
         );
       })}

--- a/components/partials/create/project/parts/CreateProjectNav.tsx
+++ b/components/partials/create/project/parts/CreateProjectNav.tsx
@@ -48,29 +48,31 @@ export default function CreateProjectNav(props: Props) {
       style={{ borderRadius: "var(--ifr-radius-md)", padding: "24px" }}
       aria-label={t("Sections")}
     >
-      {sections.map(section => {
-        const isActive = activeId === section.id;
-        const isRequired = section.required?.includes(projectType);
+      {sections
+        .filter(section => !section.hideInNavByType?.[projectType])
+        .map(section => {
+          const isActive = activeId === section.id;
+          const isRequired = section.required?.includes(projectType);
 
-        return (
-          <button
-            key={section.id}
-            type="button"
-            onClick={() => scrollTo(section.id)}
-            className="text-left border-none cursor-pointer transition-colors bg-transparent hover:opacity-70"
-            style={{
-              fontFamily: "var(--ifr-font-body)",
-              fontSize: "var(--ifr-fs-base)",
-              fontWeight: isActive ? "var(--ifr-fw-semibold)" : "var(--ifr-fw-medium)",
-              color: "var(--ifr-text-primary)",
-              padding: "4px 0",
-            }}
-          >
-            {section.navLabelByType?.[projectType] || section.navLabel}
-            {isRequired && <span style={{ color: "var(--ifr-red)" }}>{" *"}</span>}
-          </button>
-        );
-      })}
+          return (
+            <button
+              key={section.id}
+              type="button"
+              onClick={() => scrollTo(section.id)}
+              className="text-left border-none cursor-pointer transition-colors bg-transparent hover:opacity-70"
+              style={{
+                fontFamily: "var(--ifr-font-body)",
+                fontSize: "var(--ifr-fs-base)",
+                fontWeight: isActive ? "var(--ifr-fw-semibold)" : "var(--ifr-fw-medium)",
+                color: "var(--ifr-text-primary)",
+                padding: "4px 0",
+              }}
+            >
+              {section.navLabelByType?.[projectType] || section.navLabel}
+              {isRequired && <span style={{ color: "var(--ifr-red)" }}>{" *"}</span>}
+            </button>
+          );
+        })}
     </nav>
   );
 }

--- a/components/partials/create/project/parts/CreateProjectSubmit.tsx
+++ b/components/partials/create/project/parts/CreateProjectSubmit.tsx
@@ -11,6 +11,8 @@ export default function CreateProjectSubmit() {
   const typeAsProjectType = type.charAt(0).toUpperCase() + type.slice(1);
   const { formState, getValues } = useFormContext();
   const { isValid } = formState;
+  const isDesign = type === "design";
+  const primaryLabel = isDesign ? t("Publish design") : t("Save");
   const { SaveDraftButton, DeleteDraftButton, EditDraftButton } = useFormSaveDraft(
     `${getValues("main.title")}`,
     typeAsProjectType as ProjectType
@@ -32,18 +34,19 @@ export default function CreateProjectSubmit() {
           id="project-create-submit"
           type="submit"
           disabled={!isValid}
-          className="border-none cursor-pointer text-white transition-opacity hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="border-none cursor-pointer transition-opacity hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
           style={{
             height: "var(--ifr-control-height)",
             borderRadius: "var(--ifr-radius-sm)",
-            backgroundColor: "var(--ifr-green)",
+            backgroundColor: "var(--ifr-yellow)",
+            color: "var(--ifr-text-primary)",
             fontFamily: "var(--ifr-font-body)",
             fontSize: "var(--ifr-fs-base)",
-            fontWeight: "var(--ifr-fw-semibold)",
+            fontWeight: "var(--ifr-fw-medium)",
             padding: "0 24px",
           }}
         >
-          {t("Save")}
+          {primaryLabel}
         </button>
       </div>
     </div>

--- a/components/partials/create/project/steps/MainStep.schema.ts
+++ b/components/partials/create/project/steps/MainStep.schema.ts
@@ -5,6 +5,8 @@ export interface MainStepValues {
   description: string;
   link: string;
   tags: Array<string>;
+  bom?: string;
+  complexity?: string;
 }
 
 export const mainStepDefaultValues: MainStepValues = {
@@ -12,6 +14,8 @@ export const mainStepDefaultValues: MainStepValues = {
   description: "",
   link: "",
   tags: [],
+  bom: "",
+  complexity: "",
 };
 
 export const mainStepSchema = () =>
@@ -19,6 +23,8 @@ export const mainStepSchema = () =>
     title: yup.string().required(),
     link: yup.string().url().required(),
     tags: yup.array().of(yup.string()),
+    bom: yup.string().url().notRequired().default(""),
+    complexity: yup.string().notRequired().default(""),
     description: yup
       .string()
       .test(

--- a/components/partials/create/project/steps/MainStep.tsx
+++ b/components/partials/create/project/steps/MainStep.tsx
@@ -1,4 +1,5 @@
-import { Stack, TextField } from "@bbtgnn/polaris-interfacer";
+import { RangeSlider, Stack, TextField } from "@bbtgnn/polaris-interfacer";
+import { complexityLevelFromLabel, complexityLevelFromNumber } from "lib/tagging";
 import BrMdEditor from "components/brickroom/BrMdEditor";
 import PTitleSubtitle from "components/polaris/PTitleSubtitle";
 import { ProjectType } from "components/types";
@@ -113,6 +114,67 @@ export default function MainStep() {
         requiredIndicator={isRequired(mainStepSchema(), "description")}
         error={errors.main?.description?.message}
       />
+
+      {projectType === ProjectType.DESIGN && (
+        <>
+          {(() => {
+            const stored = watch("main.complexity");
+            const current = complexityLevelFromLabel(stored) || complexityLevelFromNumber(3);
+            const display = `${t(current.label)} (${current.level})`;
+            return (
+              <div className="flex flex-col gap-3">
+                <div className="text-ifr-text-primary" style={{ fontWeight: 600, fontSize: "var(--ifr-fs-md)" }}>
+                  {t("Complexity of this project")} <span style={{ color: "var(--ifr-danger)" }}>*</span>
+                </div>
+                <RangeSlider
+                  id="main-complexity"
+                  label={t("Complexity of this project")}
+                  labelHidden
+                  min={1}
+                  max={5}
+                  step={1}
+                  value={current.level}
+                  output={false}
+                  onChange={v =>
+                    setValue("main.complexity", complexityLevelFromNumber(Number(v)).label, formSetValueOptions)
+                  }
+                />
+                <div className="flex justify-between text-ifr-text-secondary" style={{ fontSize: "var(--ifr-fs-sm)" }}>
+                  {[1, 2, 3, 4, 5].map(n => (
+                    <span key={n}>{n}</span>
+                  ))}
+                </div>
+                <div className="text-ifr-text-primary" style={{ fontWeight: 600 }}>
+                  {display}
+                </div>
+                <p className="text-ifr-text-secondary m-0" style={{ fontSize: "var(--ifr-fs-sm)" }}>
+                  {current.description}
+                </p>
+              </div>
+            );
+          })()}
+
+          <Controller
+            control={control}
+            name="main.bom"
+            render={({ field: { onChange, onBlur, name, value } }) => (
+              <TextField
+                type="text"
+                id={getIdFromFormName(name)}
+                name={name}
+                value={value || ""}
+                autoComplete="off"
+                onChange={onChange}
+                onBlur={onBlur}
+                placeholder={"https://github.com/you/project/blob/main/BOM.csv"}
+                label={t("Bill of Materials (BOM)")}
+                helpText={t("Add a link to your bill of materials. The link will be visible in the design page.")}
+                error={errors.main?.bom?.message}
+              />
+            )}
+          />
+        </>
+      )}
     </Stack>
   );
 }

--- a/components/partials/create/project/steps/PowerRequirementsStep.schema.ts
+++ b/components/partials/create/project/steps/PowerRequirementsStep.schema.ts
@@ -1,0 +1,23 @@
+import * as yup from "yup";
+
+export interface PowerRequirementsStepValues {
+  powerSources: string[];
+  powerRequirementW: string;
+}
+
+export const powerRequirementsStepDefaultValues: PowerRequirementsStepValues = {
+  powerSources: [],
+  powerRequirementW: "50",
+};
+
+export const powerRequirementsStepSchema = () =>
+  yup.object().shape({
+    powerSources: yup.array().of(yup.string().required()).default([]),
+    powerRequirementW: yup
+      .string()
+      .test("is-number-or-empty", "Must be a number", value => {
+        if (!value) return true;
+        return Number.isFinite(Number(value));
+      })
+      .default("50"),
+  });

--- a/components/partials/create/project/steps/PowerRequirementsStep.tsx
+++ b/components/partials/create/project/steps/PowerRequirementsStep.tsx
@@ -1,0 +1,109 @@
+import { RangeSlider, Stack } from "@bbtgnn/polaris-interfacer";
+import PHelp from "components/polaris/PHelp";
+import PTitleSubtitle from "components/polaris/PTitleSubtitle";
+import { formSetValueOptions } from "lib/formSetValueOptions";
+import { useTranslation } from "next-i18next";
+import { useState } from "react";
+import { useFormContext } from "react-hook-form";
+import { CreateProjectValues } from "../CreateProjectForm";
+
+export {
+  type PowerRequirementsStepValues,
+  powerRequirementsStepDefaultValues,
+  powerRequirementsStepSchema,
+} from "./PowerRequirementsStep.schema";
+
+// Power source options matching the Figma prototype's design form.
+export const DESIGN_POWER_SOURCE_OPTIONS = [
+  "110V AC",
+  "230V AC",
+  "12V DC",
+  "5V DC",
+  "Battery Powered",
+  "USB-C PD",
+  "Solar Compatible",
+];
+
+export default function PowerRequirementsStep() {
+  const { t } = useTranslation("createProjectProps");
+  const form = useFormContext<CreateProjectValues>();
+  const { watch, setValue } = form;
+
+  const POWER_FORM_KEY = "power";
+  const powerData = watch(POWER_FORM_KEY);
+  const selectedSources = powerData?.powerSources || [];
+
+  const currentW = Number(powerData?.powerRequirementW) || 0;
+  const [watts, setWatts] = useState(currentW);
+
+  const toggleSource = (source: string, checked: boolean) => {
+    const next = checked ? [...selectedSources, source] : selectedSources.filter(s => s !== source);
+    setValue(POWER_FORM_KEY, { ...powerData, powerSources: next }, formSetValueOptions);
+  };
+
+  return (
+    <Stack vertical spacing="loose">
+      <PTitleSubtitle title={t("Power Requirements")} />
+      <PHelp helpText={t("Specify the power source and consumption of your project.")} />
+
+      <div className="flex flex-col gap-3">
+        <div className="text-ifr-text-primary" style={{ fontWeight: 600, fontSize: "var(--ifr-fs-md)" }}>
+          {t("Power Source")}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {DESIGN_POWER_SOURCE_OPTIONS.map(source => {
+            const checked = selectedSources.includes(source);
+            return (
+              <label
+                key={source}
+                className="flex items-center gap-2 cursor-pointer select-none px-3 py-2 border transition-colors"
+                style={{
+                  borderRadius: "var(--ifr-radius-sm)",
+                  borderColor: checked ? "var(--ifr-green)" : "var(--ifr-border)",
+                  backgroundColor: checked ? "var(--ifr-active)" : "var(--ifr-surface)",
+                  fontFamily: "var(--ifr-font-body)",
+                  fontSize: "var(--ifr-fs-sm)",
+                  fontWeight: checked ? "var(--ifr-fw-medium)" : "var(--ifr-fw-regular)",
+                  color: "var(--ifr-text-primary)",
+                }}
+              >
+                <input
+                  type="checkbox"
+                  className="accent-[var(--ifr-green)]"
+                  checked={checked}
+                  onChange={e => toggleSource(source, e.target.checked)}
+                />
+                {t(source)}
+              </label>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <div className="text-ifr-text-primary" style={{ fontWeight: 600, fontSize: "var(--ifr-fs-md)" }}>
+          {t("Power Requirement (Watts)")}
+        </div>
+        <RangeSlider
+          id="power-requirement-watts"
+          label={t("Power Requirement (Watts)")}
+          labelHidden
+          min={0}
+          max={1500}
+          step={25}
+          value={watts}
+          output
+          onChange={v => {
+            const n = Number(v);
+            setWatts(n);
+            setValue(POWER_FORM_KEY, { ...powerData, powerRequirementW: String(n) }, formSetValueOptions);
+          }}
+        />
+        <div className="flex items-center gap-1 text-ifr-text-primary" style={{ fontSize: "var(--ifr-fs-base)" }}>
+          <span style={{ fontWeight: "var(--ifr-fw-medium)" }}>{watts}</span>
+          <span className="text-ifr-text-secondary">{t("W")}</span>
+        </div>
+      </div>
+    </Stack>
+  );
+}

--- a/components/partials/create/project/steps/ProductFiltersStep.schema.ts
+++ b/components/partials/create/project/steps/ProductFiltersStep.schema.ts
@@ -9,6 +9,8 @@ export interface ProductFiltersStepValues {
   repairability: boolean;
   energyKwh: string;
   co2Kg: string;
+  price?: string;
+  availability?: string;
 }
 
 export const productFiltersStepDefaultValues: ProductFiltersStepValues = {
@@ -20,6 +22,8 @@ export const productFiltersStepDefaultValues: ProductFiltersStepValues = {
   repairability: false,
   energyKwh: "",
   co2Kg: "",
+  price: "",
+  availability: "",
 };
 
 export const productFiltersStepSchema = () =>
@@ -57,4 +61,6 @@ export const productFiltersStepSchema = () =>
         return Number.isFinite(Number(value));
       })
       .default(""),
+    price: yup.string().default(""),
+    availability: yup.string().default(""),
   });

--- a/components/partials/create/project/steps/ProductFiltersStep.tsx
+++ b/components/partials/create/project/steps/ProductFiltersStep.tsx
@@ -1,4 +1,4 @@
-import { Stack, TextField } from "@bbtgnn/polaris-interfacer";
+import { Select, Stack, TextField } from "@bbtgnn/polaris-interfacer";
 import PHelp from "components/polaris/PHelp";
 import PTitleSubtitle from "components/polaris/PTitleSubtitle";
 import { formSetValueOptions } from "lib/formSetValueOptions";
@@ -29,6 +29,31 @@ export default function ProductFiltersStep() {
   return (
     <Stack vertical spacing="loose">
       <PTitleSubtitle title={t("Product specifications")} subtitle={t("These fields help users filter products.")} />
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <TextField
+          type="text"
+          label={t("Price")}
+          placeholder={t("e.g. €1,200")}
+          value={values.price || ""}
+          onChange={value => setValue("productFilters.price", value, formSetValueOptions)}
+          helpText={t("Indicative price shown on the product page.")}
+          autoComplete="off"
+        />
+        <Select
+          label={t("Availability")}
+          options={[
+            { label: t("Select availability…"), value: "" },
+            { label: t("Available Now"), value: "Available Now" },
+            { label: t("Made to Order"), value: "Made to Order" },
+            { label: t("Limited Stock"), value: "Limited Stock" },
+            { label: t("Out of Stock"), value: "Out of Stock" },
+          ]}
+          value={values.availability || ""}
+          onChange={value => setValue("productFilters.availability", value, formSetValueOptions)}
+          helpText={t("Current availability shown on the product page.")}
+        />
+      </div>
 
       <Stack vertical spacing="tight">
         <PHelp helpText={t("Select one or more categories for your product")} />

--- a/components/partials/project/projectSections.tsx
+++ b/components/partials/project/projectSections.tsx
@@ -11,6 +11,7 @@ import MachinesStep from "../create/project/steps/MachinesStep";
 import MainStep from "../create/project/steps/MainStep";
 import MaterialsStep from "../create/project/steps/MaterialsStep";
 import ModelFilesStep from "../create/project/steps/ModelFilesStep";
+import PowerRequirementsStep from "../create/project/steps/PowerRequirementsStep";
 import ProductFiltersStep from "../create/project/steps/ProductFiltersStep";
 import RelationsStep from "../create/project/steps/RelationsStep";
 import ServiceFiltersStep from "../create/project/steps/ServiceFiltersStep";
@@ -27,6 +28,10 @@ export type ProjectSection = {
   for?: Array<ProjectType>;
   required?: Array<ProjectType>;
   editPage?: string;
+  /** Section index used to order nav + rendered sections per project type. */
+  orderByType?: Partial<Record<ProjectType, number>>;
+  /** Hide the nav entry for a project type (section still renders). */
+  hideInNavByType?: Partial<Record<ProjectType, boolean>>;
 };
 
 export const projectSections: Array<ProjectSection> = [
@@ -37,6 +42,7 @@ export const projectSections: Array<ProjectSection> = [
     component: <ImportDesignStep />,
     for: [ProjectType.DESIGN],
     required: [ProjectType.DESIGN],
+    orderByType: { [ProjectType.DESIGN]: 10 },
   },
   {
     navLabel: "General info",
@@ -44,6 +50,8 @@ export const projectSections: Array<ProjectSection> = [
     component: <MainStep />,
     required: [ProjectType.PRODUCT, ProjectType.SERVICE, ProjectType.DESIGN, ProjectType.MACHINE],
     editPage: "edit",
+    orderByType: { [ProjectType.DESIGN]: 20 },
+    hideInNavByType: { [ProjectType.DESIGN]: true },
   },
   {
     navLabel: "Design source",
@@ -65,6 +73,8 @@ export const projectSections: Array<ProjectSection> = [
     component: <ImagesStep />,
     required: [ProjectType.PRODUCT, ProjectType.SERVICE, ProjectType.DESIGN, ProjectType.MACHINE],
     editPage: "edit/images",
+    orderByType: { [ProjectType.DESIGN]: 30 },
+    hideInNavByType: { [ProjectType.DESIGN]: true },
   },
   {
     navLabel: "3D files",
@@ -73,6 +83,7 @@ export const projectSections: Array<ProjectSection> = [
     component: <ModelFilesStep />,
     for: [ProjectType.DESIGN],
     editPage: "edit/model",
+    orderByType: { [ProjectType.DESIGN]: 60 },
   },
   {
     navLabel: "Service details",
@@ -117,6 +128,7 @@ export const projectSections: Array<ProjectSection> = [
     component: <LicenseStep />,
     for: [ProjectType.DESIGN],
     editPage: "edit/licenses",
+    orderByType: { [ProjectType.DESIGN]: 40 },
   },
   {
     navLabel: "Contributors",
@@ -125,6 +137,7 @@ export const projectSections: Array<ProjectSection> = [
     component: <ContributorsStep />,
     for: [ProjectType.DESIGN, ProjectType.PRODUCT, ProjectType.SERVICE, ProjectType.MACHINE],
     editPage: "edit/contributors",
+    orderByType: { [ProjectType.DESIGN]: 90 },
   },
   {
     navLabel: "Included",
@@ -132,6 +145,8 @@ export const projectSections: Array<ProjectSection> = [
     component: <RelationsStep />,
     for: [ProjectType.DESIGN, ProjectType.PRODUCT, ProjectType.SERVICE, ProjectType.MACHINE],
     editPage: "edit/relations",
+    orderByType: { [ProjectType.DESIGN]: 100 },
+    hideInNavByType: { [ProjectType.DESIGN]: true },
   },
   {
     navLabel: "Machines",
@@ -140,6 +155,7 @@ export const projectSections: Array<ProjectSection> = [
     component: <MachinesStep />,
     for: [ProjectType.PRODUCT, ProjectType.DESIGN],
     editPage: "edit/machines",
+    orderByType: { [ProjectType.DESIGN]: 70 },
   },
   {
     navLabel: "Materials",
@@ -147,13 +163,29 @@ export const projectSections: Array<ProjectSection> = [
     id: "materials",
     component: <MaterialsStep />,
     for: [ProjectType.PRODUCT, ProjectType.DESIGN],
+    orderByType: { [ProjectType.DESIGN]: 50 },
+  },
+  {
+    navLabel: "Power requirements",
+    id: "power",
+    component: <PowerRequirementsStep />,
+    for: [ProjectType.DESIGN],
+    orderByType: { [ProjectType.DESIGN]: 80 },
   },
 ];
 
 //
 
 export function getSectionsByProjectType(projectType: ProjectType): Array<ProjectSection> {
-  return projectSections.filter(section => !section.for || section.for.includes(projectType));
+  return projectSections
+    .filter(section => !section.for || section.for.includes(projectType))
+    .sort((a, b) => {
+      const oa = a.orderByType?.[projectType] ?? Number.MAX_SAFE_INTEGER;
+      const ob = b.orderByType?.[projectType] ?? Number.MAX_SAFE_INTEGER;
+      if (oa !== ob) return oa - ob;
+      // Stable fallback to declaration order
+      return projectSections.indexOf(a) - projectSections.indexOf(b);
+    });
 }
 
 export function getEditSectionsByProjectType(projectType: ProjectType): Array<ProjectSection> {

--- a/components/partials/project/projectSections.tsx
+++ b/components/partials/project/projectSections.tsx
@@ -21,6 +21,7 @@ export type ProjectSectionsIDs = keyof CreateProjectValues | "importDesign" | "i
 
 export type ProjectSection = {
   navLabel: string;
+  navLabelByType?: Partial<Record<ProjectType, string>>;
   id: ProjectSectionsIDs;
   component: React.ReactNode;
   for?: Array<ProjectType>;
@@ -31,9 +32,11 @@ export type ProjectSection = {
 export const projectSections: Array<ProjectSection> = [
   {
     navLabel: "Import design",
+    navLabelByType: { [ProjectType.DESIGN]: "Repository info" },
     id: "importDesign",
     component: <ImportDesignStep />,
     for: [ProjectType.DESIGN],
+    required: [ProjectType.DESIGN],
   },
   {
     navLabel: "General info",
@@ -65,6 +68,7 @@ export const projectSections: Array<ProjectSection> = [
   },
   {
     navLabel: "3D files",
+    navLabelByType: { [ProjectType.DESIGN]: "CAD & 3D files" },
     id: "modelFiles",
     component: <ModelFilesStep />,
     for: [ProjectType.DESIGN],
@@ -108,6 +112,7 @@ export const projectSections: Array<ProjectSection> = [
   },
   {
     navLabel: "Licenses",
+    navLabelByType: { [ProjectType.DESIGN]: "License info" },
     id: "licenses",
     component: <LicenseStep />,
     for: [ProjectType.DESIGN],
@@ -115,6 +120,7 @@ export const projectSections: Array<ProjectSection> = [
   },
   {
     navLabel: "Contributors",
+    navLabelByType: { [ProjectType.DESIGN]: "Contributors and included projects" },
     id: "contributors",
     component: <ContributorsStep />,
     for: [ProjectType.DESIGN, ProjectType.PRODUCT, ProjectType.SERVICE, ProjectType.MACHINE],
@@ -129,16 +135,18 @@ export const projectSections: Array<ProjectSection> = [
   },
   {
     navLabel: "Machines",
+    navLabelByType: { [ProjectType.DESIGN]: "Required tools and machine code" },
     id: "machines",
     component: <MachinesStep />,
-    for: [ProjectType.PRODUCT],
+    for: [ProjectType.PRODUCT, ProjectType.DESIGN],
     editPage: "edit/machines",
   },
   {
     navLabel: "Materials",
+    navLabelByType: { [ProjectType.DESIGN]: "Materials needed" },
     id: "materials",
     component: <MaterialsStep />,
-    for: [ProjectType.PRODUCT],
+    for: [ProjectType.PRODUCT, ProjectType.DESIGN],
   },
 ];
 

--- a/components/polaris/PTitleSubtitle.tsx
+++ b/components/polaris/PTitleSubtitle.tsx
@@ -1,31 +1,50 @@
-import { Stack, Text, TextProps } from "@bbtgnn/polaris-interfacer";
+import { Stack } from "@bbtgnn/polaris-interfacer";
 
 export interface Props {
   title?: string | React.ReactNode;
   subtitle?: string | React.ReactNode;
-  titleTag?: "h1" | "h2";
+  titleTag?: "h1" | "h2" | "h3";
 }
 
+// Section header typography aligned with the Figma prototype:
+// title = Space Grotesk 20px/700, subtitle = IBM Plex Sans 14px subdued.
 export default function PTitleSubtitle(props: Props) {
   const { title = "", subtitle = "", titleTag = "h1" } = props;
 
-  const titleVariant: Record<string, TextProps["variant"]> = {
-    h1: "heading2xl",
-    h2: "headingXl",
-  };
-
   return (
     <Stack vertical spacing="baseTight">
-      {title && (
-        <Text variant={titleVariant[titleTag]} as={titleTag}>
-          {title}
-        </Text>
-      )}
+      {title && <Text_ as={titleTag}>{title}</Text_>}
       {subtitle && (
-        <Text variant="bodyMd" as="p" color="subdued">
+        <p
+          className="m-0"
+          style={{
+            fontFamily: "var(--ifr-font-body)",
+            fontSize: "var(--ifr-fs-base)",
+            fontWeight: "var(--ifr-fw-regular)",
+            color: "var(--ifr-text-secondary)",
+            lineHeight: "1.5",
+          }}
+        >
           {subtitle}
-        </Text>
+        </p>
       )}
     </Stack>
+  );
+}
+
+function Text_({ as: Tag, children }: { as: "h1" | "h2" | "h3"; children: React.ReactNode }) {
+  return (
+    <Tag
+      className="m-0"
+      style={{
+        fontFamily: "var(--ifr-font-heading)",
+        fontSize: "var(--ifr-fs-lg)",
+        fontWeight: "var(--ifr-fw-bold)",
+        color: "var(--ifr-text-primary)",
+        lineHeight: "1.5",
+      }}
+    >
+      {children}
+    </Tag>
   );
 }

--- a/hooks/useProjectCRUD.ts
+++ b/hooks/useProjectCRUD.ts
@@ -195,6 +195,9 @@ export const useProjectCRUD = () => {
       const complexityTags = formData.main.complexity
         ? ([prefixedTag(COMPLEXITY_PREFIX, formData.main.complexity)].filter(Boolean) as string[])
         : [];
+      const powerSourceTags = (formData.power?.powerSources || [])
+        .map(s => prefixedTag(TAG_PREFIX.POWER_COMPAT, s))
+        .filter(Boolean) as string[];
       const baseTags = normalizeUserTagsForSave(formData.main.tags);
 
       const tags = Array.from(
@@ -207,6 +210,7 @@ export const useProjectCRUD = () => {
           ...availabilityTags,
           ...licenseTags,
           ...complexityTags,
+          ...powerSourceTags,
         ])
       );
 
@@ -227,6 +231,12 @@ export const useProjectCRUD = () => {
         ...(modelUrls.length > 0 && { models: modelUrls }),
         ...(formData.main.bom && { bom: formData.main.bom }),
         ...(formData.main.complexity && { complexity: formData.main.complexity }),
+        ...(formData.power?.powerSources?.length && {
+          powerSources: formData.power.powerSources,
+        }),
+        ...(formData.power?.powerRequirementW && {
+          powerRequirementW: formData.power.powerRequirementW,
+        }),
         ...((formData.productFilters as any)?.price && { price: (formData.productFilters as any).price }),
         ...((formData.productFilters as any)?.availability && {
           availability: (formData.productFilters as any).availability,

--- a/hooks/useProjectCRUD.ts
+++ b/hooks/useProjectCRUD.ts
@@ -6,6 +6,7 @@ import useWallet from "hooks/useWallet";
 import { IdeaPoints, StrengthsPoints } from "lib/PointsDistribution";
 import { errorFormatter } from "lib/errorFormatter";
 import {
+  COMPLEXITY_PREFIX,
   derivedProductFilterTags,
   MANUFACTURABLE_TRUE_TAG,
   normalizeUserTagsForSave,
@@ -191,6 +192,9 @@ export const useProjectCRUD = () => {
       const licenseTags = (formData.licenses || [])
         .map(l => prefixedTag(TAG_PREFIX.LICENSE, l.licenseId))
         .filter(Boolean) as string[];
+      const complexityTags = formData.main.complexity
+        ? ([prefixedTag(COMPLEXITY_PREFIX, formData.main.complexity)].filter(Boolean) as string[])
+        : [];
       const baseTags = normalizeUserTagsForSave(formData.main.tags);
 
       const tags = Array.from(
@@ -202,6 +206,7 @@ export const useProjectCRUD = () => {
           ...serviceTypeTags,
           ...availabilityTags,
           ...licenseTags,
+          ...complexityTags,
         ])
       );
 
@@ -220,6 +225,12 @@ export const useProjectCRUD = () => {
         design: formData.linkedDesign || false,
         image: imageUrls.length === 1 ? imageUrls[0] : imageUrls,
         ...(modelUrls.length > 0 && { models: modelUrls }),
+        ...(formData.main.bom && { bom: formData.main.bom }),
+        ...(formData.main.complexity && { complexity: formData.main.complexity }),
+        ...((formData.productFilters as any)?.price && { price: (formData.productFilters as any).price }),
+        ...((formData.productFilters as any)?.availability && {
+          availability: (formData.productFilters as any).availability,
+        }),
       };
 
       // Create project

--- a/lib/tagging.ts
+++ b/lib/tagging.ts
@@ -29,7 +29,54 @@ export {
   POWER_REQUIREMENT_THRESHOLDS_W,
   ENERGY_THRESHOLDS_KWH,
   CO2_THRESHOLDS_KG,
+  COMPLEXITY_OPTIONS,
 } from "@dyne/interfacer-client";
+import { TAG_PREFIX as SDK_TAG_PREFIX } from "@dyne/interfacer-client";
+
+// Complexity tag prefix, sourced from the SDK.
+export const COMPLEXITY_PREFIX: string = SDK_TAG_PREFIX.COMPLEXITY;
+
+// 1–5 complexity scale matching the Figma prototype's slider.
+export interface ComplexityLevel {
+  level: number;
+  label: string;
+  description: string;
+}
+
+export const COMPLEXITY_LEVELS: ComplexityLevel[] = [
+  {
+    level: 1,
+    label: "Beginner",
+    description: "Basic assembly with common tools; no soldering or programming required.",
+  },
+  {
+    level: 2,
+    label: "Easy",
+    description: "A few simple skills needed: basic hand tools and straightforward assembly.",
+  },
+  {
+    level: 3,
+    label: "Moderate",
+    description:
+      "Multiple skills needed: electronics assembly, firmware configuration, and basic mechanical fabrication.",
+  },
+  {
+    level: 4,
+    label: "Advanced",
+    description: "Specialized skills needed: PCB work, firmware development, and precision fabrication.",
+  },
+  {
+    level: 5,
+    label: "Expert",
+    description: "Expert-level build: complex electronics, custom firmware, and advanced fabrication.",
+  },
+];
+
+export const complexityLevelFromLabel = (label?: string): ComplexityLevel | undefined =>
+  COMPLEXITY_LEVELS.find(l => l.label.toLowerCase() === (label || "").toLowerCase());
+
+export const complexityLevelFromNumber = (n: number): ComplexityLevel =>
+  COMPLEXITY_LEVELS.find(l => l.level === n) || COMPLEXITY_LEVELS[2];
 
 export interface ProductFilterMetadata {
   categories?: string[];

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@bbtgnn/polaris-interfacer": "^0.1.0",
     "@bbtgnn/polaris-interfacer-tokens": "^6.3.0",
     "@carbon/icons-react": "^11.68.0",
-    "@dyne/interfacer-client": "^0.5.0",
+    "@dyne/interfacer-client": "^0.6.0",
     "@fontsource/ibm-plex-sans": "^5.2.8",
     "@fontsource/space-grotesk": "^5.1.10",
     "@graphql-codegen/cli": "^2.16.5",

--- a/pages/project/[id]/edit/specs.tsx
+++ b/pages/project/[id]/edit/specs.tsx
@@ -88,6 +88,14 @@ const EditSpecs: NextPageWithLayout = () => {
       energyKwh:
         typeof existing.energyKwh === "number" ? String(existing.energyKwh) : productFiltersStepDefaultValues.energyKwh,
       co2Kg: typeof existing.co2Kg === "number" ? String(existing.co2Kg) : productFiltersStepDefaultValues.co2Kg,
+      price:
+        (project.metadata?.price as string | undefined) ||
+        (existing.price as string | undefined) ||
+        productFiltersStepDefaultValues.price,
+      availability:
+        (project.metadata?.availability as string | undefined) ||
+        (existing.availability as string | undefined) ||
+        productFiltersStepDefaultValues.availability,
     },
   };
 
@@ -121,6 +129,8 @@ const EditSpecs: NextPageWithLayout = () => {
       powerRequirementW: Number.isFinite(powerRequirementW as number) ? (powerRequirementW as number) : undefined,
       energyKwh: Number.isFinite(energyKwh as number) ? (energyKwh as number) : undefined,
       co2Kg: Number.isFinite(co2Kg as number) ? (co2Kg as number) : undefined,
+      price: values.price || undefined,
+      availability: values.availability || undefined,
     };
   };
 
@@ -149,7 +159,11 @@ const EditSpecs: NextPageWithLayout = () => {
       },
     });
 
-    await updateMetadata(project, { productFilters: normalized });
+    await updateMetadata(project, {
+      productFilters: normalized,
+      price: normalized.price || "",
+      availability: normalized.availability || "",
+    });
   }
 
   return (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^11.68.0
         version: 11.69.0(react@18.2.0)
       '@dyne/interfacer-client':
-        specifier: ^0.5.0
-        version: 0.5.0(zenroom@5.36.1)
+        specifier: ^0.6.0
+        version: 0.6.0(zenroom@5.36.1)
       '@fontsource/ibm-plex-sans':
         specifier: ^5.2.8
         version: 5.2.8
@@ -688,8 +688,8 @@ packages:
     peerDependencies:
       postcss-selector-parser: ^6.0.10
 
-  '@dyne/interfacer-client@0.5.0':
-    resolution: {integrity: sha512-4khFTA3oaunsyKEaqcle8axvIOt25ojSloiyOcpySZrP45PlZgdoJ4O08O7pDY9lj8jw/bFrqX16I3XyY4mGEg==}
+  '@dyne/interfacer-client@0.6.0':
+    resolution: {integrity: sha512-lEfMP+yWum4swmutyY6qahWujI7nJJjEzsjwumPdUyPllxHWTKjfAD3UadqV3kcAYSTH3NJudlaT0PmvDcoqxA==}
     peerDependencies:
       zenroom: ^5.36.1
 
@@ -5791,7 +5791,7 @@ snapshots:
     dependencies:
       postcss-selector-parser: 6.1.2
 
-  '@dyne/interfacer-client@0.5.0(zenroom@5.36.1)':
+  '@dyne/interfacer-client@0.6.0(zenroom@5.36.1)':
     dependencies:
       base64url: 3.0.1
       zenroom: 5.36.1

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -8,10 +8,7 @@
   "Value of this project": "Value of this project",
   "Load more": "Load more...",
   "projects": "Projects",
-  "contributorsHead": [
-    "UserName",
-    "Date"
-  ],
+  "contributorsHead": ["UserName", "Date"],
   "watch": "Watch",
   "add to list": "Add to list",
   "unwatch": "unwatch",
@@ -156,7 +153,7 @@
   "Included": "Included",
   "Include": "Include",
   "Interfacer ID:": "Interfacer ID:",
-  "Save Draft": "Save draf",
+  "Save Draft": "Save draft",
   "Submit!": "Submit!",
   "Save": "Save",
   "All projects": "All projects",

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -356,3 +356,25 @@ table {
   width: 50%;
   justify-content: flex-end;
 }
+
+/* Restore markdown list indentation inside project detail Overview (Polaris resets lists) */
+.prose ul {
+  list-style: disc !important;
+  padding-left: 1.5em !important;
+  margin: 0.5em 0 !important;
+}
+.prose ol {
+  list-style: decimal !important;
+  padding-left: 1.5em !important;
+  margin: 0.5em 0 !important;
+}
+.prose li {
+  margin: 0.25em 0 !important;
+}
+.prose ul ul,
+.prose ol ul,
+.prose ul ol,
+.prose ol ol {
+  padding-left: 1.25em !important;
+  margin: 0.25em 0 !important;
+}


### PR DESCRIPTION
## Summary

Brings the GUI closer to the Figma prototype (`same-desk-33715229.figma.site`) across catalog, detail pages, and creation forms.

## Changes

### Catalog & listing
- Sticky catalog/filter sidebar with internal scrolling (`CatalogLayout`, `CatalogFilterSidebar`)
- Location filter scoped to products/services (removed from designs); designs gain prototype-style power-source filter options
- Card images fill without bottom whitespace (`ProjectCardImage`)
- Complexity filter on designs using the new 1–5 scale

### Project detail
- Sticky detail sidebar with title + product price/availability from the form (`ProjectDetailNew`)
- Overview section non-collapsible with collapsible body; fixed bullet indentation (`DetailSection`, `globals.scss`)
- Redesigned "Included" mini-cards to the prototype's 104px horizontal layout (`ProjectsCards` → `TinyProjectCard`)

### Creation forms
- Prototype typography (Space Grotesk headings, IBM Plex body), section-nav labels, yellow "Publish design" button
- Design form: complexity 1–5 slider, BOM link, **new Power Requirements section** (power source checkboxes + 0–1500W slider), nav reordered/hidden to match the prototype's 7 items
- Product form: price + availability fields, persisted to metadata and shown in the detail sidebar
- Machine creation drawer (`MachineDrawer`) wired to the profile Machines tab
- Fixed "Save draf" → "Save draft" typo

### SDK
- Bumped `@dyne/interfacer-client` to `0.6.0` (published via the SDK repo's workflow): `COMPLEXITY_OPTIONS`, extended `CreateMachineParams` (`type`, `location`, `image`, `tags`)

## Verification
- `tsc --noEmit` and `eslint` clean
- Browser-verified: sticky sidebars, internal filter scrolling, detail sidebar price/availability, Overview behavior, mini-cards, design form nav + power section, machine drawer
- E2E: product price/availability edit persists and round-trips through `updateMetadata`

## Notes
- SDK commit: `0bf10c4` in `interfacer-client`
