### PR TITLE
feat(ui): adapt layouts for mobile screens

### DIFF
--- a/components/CatalogFilterSidebar.tsx
+++ b/components/CatalogFilterSidebar.tsx
@@ -45,6 +45,11 @@ interface CatalogFilterSidebarProps {
   variant: CatalogVariant;
   collapsed?: boolean;
   onToggle?: () => void;
+  /**
+   * Below `lg` there is no room for a permanent column, so the same panel is
+   * presented as an overlay drawer over the results instead of shrinking them.
+   */
+  asDrawer?: boolean;
 }
 
 /** Given current URL tags, a tag prefix, and the items list, return which items are currently selected */
@@ -100,9 +105,34 @@ const LICENSES = [
   "Apache 2.0",
 ];
 
-export default function CatalogFilterSidebar({ variant, collapsed = false, onToggle }: CatalogFilterSidebarProps) {
+export default function CatalogFilterSidebar({
+  variant,
+  collapsed = false,
+  onToggle,
+  asDrawer = false,
+}: CatalogFilterSidebarProps) {
   const { t } = useTranslation("common");
   const router = useRouter();
+  const drawerOpen = asDrawer && !collapsed;
+
+  // While the drawer covers the results, scrolling belongs to the drawer.
+  useEffect(() => {
+    if (!drawerOpen) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [drawerOpen]);
+
+  useEffect(() => {
+    if (!drawerOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onToggle?.();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [drawerOpen, onToggle]);
 
   // --- Geo location state ---
   const urlRadius = router.query.nearDistanceKm ? Number(router.query.nearDistanceKm) : 50;
@@ -291,376 +321,196 @@ export default function CatalogFilterSidebar({ variant, collapsed = false, onTog
 
   const hasActiveFilters = currentTags.length > 0 || !!router.query.q || hasActiveLocation;
 
-  return (
-    <div
-      className="bg-ifr-surface border-r border-ifr shrink-0 relative sticky self-start"
-      style={{
-        width: collapsed ? "0px" : "var(--ifr-sidebar-width)",
-        overflow: "hidden",
-        transition: "width 250ms ease",
-        borderRightWidth: collapsed ? "0px" : undefined,
-        top: "var(--ifr-topbar-height)",
-        maxHeight: "calc(100vh - var(--ifr-topbar-height))",
-      }}
-    >
-      <div
-        className="overflow-y-auto"
-        style={{
-          width: "var(--ifr-sidebar-width)",
-          maxHeight: "calc(100vh - var(--ifr-topbar-height))",
-          opacity: collapsed ? 0 : 1,
-          transition: "opacity 200ms ease",
-          pointerEvents: collapsed ? "none" : undefined,
-        }}
-      >
-        {/* Header */}
-        <div className="border-b border-ifr px-6 py-4 flex items-center justify-between">
-          <p
-            className="text-ifr-text-primary"
-            style={{
-              fontFamily: "var(--ifr-font-body)",
-              fontSize: "var(--ifr-fs-md)",
-              fontWeight: "var(--ifr-fw-regular)",
-            }}
+  // Filter sections — identical in the inline column and the drawer.
+  const sections = (
+    <>
+      {/* DESIGNS variant */}
+      {variant === "designs" && (
+        <>
+          <FilterSection
+            icon={<Settings size={16} />}
+            label="Machines Needed"
+            defaultOpen
+            badge={selectedMachines.length || undefined}
           >
-            {t("Filter by")}
-          </p>
-          {hasActiveFilters && (
-            <button
-              type="button"
-              onClick={clearAllFilters}
-              className="text-ifr-text-secondary hover:text-ifr-text-primary text-ifr-sm underline transition-colors cursor-pointer"
-              style={{
-                fontFamily: "var(--ifr-font-body)",
-                fontSize: "var(--ifr-fs-sm)",
-                fontWeight: "var(--ifr-fw-medium)",
-              }}
-            >
-              {t("Reset")}
-            </button>
-          )}
-        </div>
+            <CheckboxFilter
+              items={MACHINES}
+              searchPlaceholder="Search machines..."
+              selectedItems={selectedMachines}
+              onToggle={toggleTag(TAG_PREFIX.MACHINE)}
+            />
+          </FilterSection>
 
-        {/* DESIGNS variant */}
-        {variant === "designs" && (
-          <>
-            <FilterSection
-              icon={<Settings size={16} />}
-              label="Machines Needed"
-              defaultOpen
-              badge={selectedMachines.length || undefined}
-            >
-              <CheckboxFilter
-                items={MACHINES}
-                searchPlaceholder="Search machines..."
-                selectedItems={selectedMachines}
-                onToggle={toggleTag(TAG_PREFIX.MACHINE)}
-              />
-            </FilterSection>
+          <FilterSection
+            icon={<Cube size={16} />}
+            label="Materials Needed"
+            badge={selectedMaterials.length || undefined}
+          >
+            <CheckboxFilter
+              items={MATERIALS}
+              searchPlaceholder="Search materials..."
+              selectedItems={selectedMaterials}
+              onToggle={toggleTag(TAG_PREFIX.MATERIAL)}
+            />
+          </FilterSection>
 
-            <FilterSection
-              icon={<Cube size={16} />}
-              label="Materials Needed"
-              badge={selectedMaterials.length || undefined}
-            >
-              <CheckboxFilter
-                items={MATERIALS}
-                searchPlaceholder="Search materials..."
-                selectedItems={selectedMaterials}
-                onToggle={toggleTag(TAG_PREFIX.MATERIAL)}
-              />
-            </FilterSection>
+          <FilterSection
+            icon={<ScaleIcon className="w-4 h-4" />}
+            label="License"
+            badge={selectedLicenses.length || undefined}
+          >
+            <CheckboxFilter
+              items={LICENSES}
+              searchPlaceholder="Search licenses..."
+              selectedItems={selectedLicenses}
+              onToggle={toggleTag(TAG_PREFIX.LICENSE)}
+            />
+          </FilterSection>
 
-            <FilterSection
-              icon={<ScaleIcon className="w-4 h-4" />}
-              label="License"
-              badge={selectedLicenses.length || undefined}
-            >
-              <CheckboxFilter
-                items={LICENSES}
-                searchPlaceholder="Search licenses..."
-                selectedItems={selectedLicenses}
-                onToggle={toggleTag(TAG_PREFIX.LICENSE)}
-              />
-            </FilterSection>
+          <FilterSection
+            icon={<Tools size={16} />}
+            label="Manufacturability"
+            defaultOpen
+            badge={currentTags.includes(MANUFACTURABLE_TRUE_TAG) ? 1 : undefined}
+          >
+            <div className="flex flex-col gap-2.5">
+              {[
+                { value: "all", label: "All" },
+                { value: "can_be_manufactured", label: "Can be manufactured" },
+              ].map(option => {
+                const isSelected =
+                  option.value === "all"
+                    ? !currentTags.includes(MANUFACTURABLE_TRUE_TAG)
+                    : currentTags.includes(MANUFACTURABLE_TRUE_TAG);
 
-            <FilterSection
-              icon={<Tools size={16} />}
-              label="Manufacturability"
-              defaultOpen
-              badge={currentTags.includes(MANUFACTURABLE_TRUE_TAG) ? 1 : undefined}
-            >
-              <div className="flex flex-col gap-2.5">
-                {[
-                  { value: "all", label: "All" },
-                  { value: "can_be_manufactured", label: "Can be manufactured" },
-                ].map(option => {
-                  const isSelected =
-                    option.value === "all"
-                      ? !currentTags.includes(MANUFACTURABLE_TRUE_TAG)
-                      : currentTags.includes(MANUFACTURABLE_TRUE_TAG);
+                return (
+                  <div
+                    key={option.value}
+                    className="flex items-center gap-2 cursor-pointer"
+                    onClick={() => {
+                      if (isSelected) return;
 
-                  return (
+                      let newTags: string[];
+                      if (option.value === "all") {
+                        newTags = currentTags.filter(t => t !== MANUFACTURABLE_TRUE_TAG);
+                      } else {
+                        newTags = [...currentTags, MANUFACTURABLE_TRUE_TAG];
+                      }
+
+                      const query = { ...router.query };
+                      if (newTags.length > 0) {
+                        query.tags = newTags.join(",");
+                      } else {
+                        delete query.tags;
+                      }
+                      router.push({ pathname: router.pathname, query }, undefined, { shallow: true });
+                    }}
+                  >
                     <div
-                      key={option.value}
-                      className="flex items-center gap-2 cursor-pointer"
-                      onClick={() => {
-                        if (isSelected) return;
-
-                        let newTags: string[];
-                        if (option.value === "all") {
-                          newTags = currentTags.filter(t => t !== MANUFACTURABLE_TRUE_TAG);
-                        } else {
-                          newTags = [...currentTags, MANUFACTURABLE_TRUE_TAG];
-                        }
-
-                        const query = { ...router.query };
-                        if (newTags.length > 0) {
-                          query.tags = newTags.join(",");
-                        } else {
-                          delete query.tags;
-                        }
-                        router.push({ pathname: router.pathname, query }, undefined, { shallow: true });
+                      className="w-4 h-4 border shrink-0 flex items-center justify-center transition-colors"
+                      style={{
+                        borderRadius: "50%",
+                        backgroundColor: isSelected ? "var(--ifr-green)" : "var(--ifr-bg-surface)",
+                        borderColor: isSelected ? "var(--ifr-green)" : "var(--ifr-border)",
                       }}
                     >
-                      <div
-                        className="w-4 h-4 border shrink-0 flex items-center justify-center transition-colors"
-                        style={{
-                          borderRadius: "50%",
-                          backgroundColor: isSelected ? "var(--ifr-green)" : "var(--ifr-bg-surface)",
-                          borderColor: isSelected ? "var(--ifr-green)" : "var(--ifr-border)",
-                        }}
-                      >
-                        {isSelected && <div className="w-1.5 h-1.5 bg-white" style={{ borderRadius: "50%" }} />}
-                      </div>
-                      <span
-                        className="text-ifr-text-primary"
-                        style={{ fontFamily: "var(--ifr-font-body)", fontSize: "var(--ifr-fs-base)" }}
-                      >
-                        {t(option.label)}
-                      </span>
+                      {isSelected && <div className="w-1.5 h-1.5 bg-white" style={{ borderRadius: "50%" }} />}
                     </div>
-                  );
-                })}
-              </div>
-            </FilterSection>
-
-            <FilterSection
-              icon={<Analytics size={16} />}
-              label="Complexity"
-              badge={selectedComplexity.length || undefined}
-            >
-              <CheckboxFilter
-                items={COMPLEXITY_LABELS}
-                selectedItems={selectedComplexity}
-                onToggle={toggleTag(COMPLEXITY_PREFIX)}
-              />
-            </FilterSection>
-          </>
-        )}
-
-        {/* PRODUCTS variant */}
-        {variant === "products" && (
-          <>
-            <FilterSection
-              icon={<Settings size={16} />}
-              label="Machines Needed"
-              defaultOpen
-              badge={selectedMachines.length || undefined}
-            >
-              <CheckboxFilter
-                items={MACHINES}
-                searchPlaceholder="Search machines..."
-                selectedItems={selectedMachines}
-                onToggle={toggleTag(TAG_PREFIX.MACHINE)}
-              />
-            </FilterSection>
-
-            <FilterSection icon={<Cube size={16} />} label="Materials" badge={selectedMaterials.length || undefined}>
-              <CheckboxFilter
-                items={MATERIALS}
-                searchPlaceholder="Search materials..."
-                selectedItems={selectedMaterials}
-                onToggle={toggleTag(TAG_PREFIX.MATERIAL)}
-              />
-            </FilterSection>
-
-            <FilterSection icon={<Flash size={16} />} label="Power Requirement">
-              <DualRangeSlider
-                min={0}
-                max={2000}
-                step={50}
-                unit="W"
-                valueLow={powerRange[0]}
-                valueHigh={powerRange[1]}
-                onChange={(low, high) => setPowerRange([low, high])}
-              />
-            </FilterSection>
-
-            <FilterSection icon={<Tools size={16} />} label="Repairability">
-              <ToggleSwitch
-                label={t("Repair Info Available")}
-                description={t("Projects with repair and maintenance info")}
-                checked={repairInfo}
-                onChange={checked => {
-                  const newTags = checked
-                    ? [...currentTags, REPAIRABILITY_AVAILABLE_TAG]
-                    : currentTags.filter(t => t !== REPAIRABILITY_AVAILABLE_TAG);
-                  const query = { ...router.query };
-                  if (newTags.length > 0) {
-                    query.tags = newTags.join(",");
-                  } else {
-                    delete query.tags;
-                  }
-                  router.push({ pathname: router.pathname, query }, undefined, { shallow: true });
-                }}
-              />
-            </FilterSection>
-          </>
-        )}
-
-        {/* SERVICES variant */}
-        {variant === "services" && (
-          <>
-            <FilterSection
-              icon={<LocationStar size={16} />}
-              label="Location"
-              defaultOpen
-              badge={hasActiveLocation ? 1 : undefined}
-            >
-              <div className="flex flex-col gap-2" ref={locationDropdownRef}>
-                {locationLabel ? (
-                  <div
-                    className="flex items-center gap-2 px-3 bg-ifr-active border border-ifr rounded-ifr-sm"
-                    style={{ height: "var(--ifr-control-height)" }}
-                  >
-                    <LocationStar size={14} className="text-ifr-green shrink-0" />
                     <span
-                      className="flex-1 text-ifr-text-primary truncate"
+                      className="text-ifr-text-primary"
                       style={{ fontFamily: "var(--ifr-font-body)", fontSize: "var(--ifr-fs-base)" }}
                     >
-                      {locationLabel}
+                      {t(option.label)}
                     </span>
-                    <button
-                      type="button"
-                      onClick={clearLocation}
-                      className="shrink-0 text-ifr-text-secondary hover:text-ifr-text-primary cursor-pointer"
-                    >
-                      <Close size={14} />
-                    </button>
                   </div>
-                ) : (
-                  <div className="relative">
-                    <input
-                      type="text"
-                      value={locationInput}
-                      onChange={e => setLocationInput(e.target.value)}
-                      onFocus={() => locationOptions.length > 0 && setShowLocationDropdown(true)}
-                      placeholder={t("Search city or address...")}
-                      className="w-full px-3 bg-ifr-form-input border border-ifr-form-input rounded-ifr-sm outline-none focus:border-ifr-green"
-                      style={{
-                        height: "var(--ifr-control-height)",
-                        fontFamily: "var(--ifr-font-body)",
-                        fontSize: "var(--ifr-fs-base)",
-                      }}
-                    />
-                    {showLocationDropdown && locationOptions.length > 0 && (
-                      <div className="absolute z-50 left-0 right-0 mt-1 bg-ifr-surface border border-ifr rounded-ifr-sm shadow-lg max-h-[200px] overflow-y-auto">
-                        {locationOptions.map(loc => (
-                          <button
-                            key={loc.id}
-                            type="button"
-                            className="w-full text-left px-3 py-2 hover:bg-ifr-hover transition-colors cursor-pointer"
-                            style={{ fontFamily: "var(--ifr-font-body)", fontSize: "var(--ifr-fs-sm)" }}
-                            onClick={() => handleLocationSelect(loc)}
-                          >
-                            {loc.title}
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                    {locationLoading && (
-                      <div className="absolute right-3 top-1/2 -translate-y-1/2">
-                        <div className="w-4 h-4 border-2 border-ifr-green border-t-transparent rounded-full animate-spin" />
-                      </div>
-                    )}
-                  </div>
-                )}
-                <label
-                  className="text-ifr-text-primary mt-2"
-                  style={{
-                    fontFamily: "var(--ifr-font-body)",
-                    fontSize: "var(--ifr-fs-sm)",
-                    fontWeight: "var(--ifr-fw-medium)",
-                  }}
-                >
-                  {t("Search Radius")}
-                </label>
-                <div className="flex flex-wrap gap-2">
-                  {[10, 25, 50, 100, 250].map(km => (
-                    <button
-                      key={km}
-                      type="button"
-                      onClick={() => handleRadiusChange(km)}
-                      className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
-                        searchRadius === km
-                          ? "bg-[#036a53] text-white"
-                          : "border border-[#c9cccf] text-[#0b1324] hover:bg-ifr-hover"
-                      }`}
-                    >
-                      {km}
-                      {t("km")}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </FilterSection>
+                );
+              })}
+            </div>
+          </FilterSection>
 
-            <FilterSection
-              icon={<Chemistry size={16} />}
-              label="Service Type"
-              defaultOpen
-              badge={selectedServiceTypes.length || undefined}
-            >
-              <CheckboxFilter
-                items={[...SERVICE_TYPE_OPTIONS]}
-                selectedItems={selectedServiceTypes}
-                onToggle={toggleTag(TAG_PREFIX.SERVICE_TYPE)}
-              />
-            </FilterSection>
+          <FilterSection
+            icon={<Analytics size={16} />}
+            label="Complexity"
+            badge={selectedComplexity.length || undefined}
+          >
+            <CheckboxFilter
+              items={COMPLEXITY_LABELS}
+              selectedItems={selectedComplexity}
+              onToggle={toggleTag(COMPLEXITY_PREFIX)}
+            />
+          </FilterSection>
+        </>
+      )}
 
-            <FilterSection
-              icon={<Time size={16} />}
-              label="Availability"
-              badge={selectedAvailability.length || undefined}
-            >
-              <CheckboxFilter
-                items={[...AVAILABILITY_OPTIONS]}
-                selectedItems={selectedAvailability}
-                onToggle={toggleTag(TAG_PREFIX.AVAILABILITY)}
-              />
-            </FilterSection>
+      {/* PRODUCTS variant */}
+      {variant === "products" && (
+        <>
+          <FilterSection
+            icon={<Settings size={16} />}
+            label="Machines Needed"
+            defaultOpen
+            badge={selectedMachines.length || undefined}
+          >
+            <CheckboxFilter
+              items={MACHINES}
+              searchPlaceholder="Search machines..."
+              selectedItems={selectedMachines}
+              onToggle={toggleTag(TAG_PREFIX.MACHINE)}
+            />
+          </FilterSection>
 
-            <FilterSection
-              icon={<Settings size={16} />}
-              label="Machines Available"
-              badge={selectedMachines.length || undefined}
-            >
-              <CheckboxFilter
-                items={MACHINES}
-                searchPlaceholder="Search machines..."
-                selectedItems={selectedMachines}
-                onToggle={toggleTag(TAG_PREFIX.MACHINE)}
-              />
-            </FilterSection>
-          </>
-        )}
+          <FilterSection icon={<Cube size={16} />} label="Materials" badge={selectedMaterials.length || undefined}>
+            <CheckboxFilter
+              items={MATERIALS}
+              searchPlaceholder="Search materials..."
+              selectedItems={selectedMaterials}
+              onToggle={toggleTag(TAG_PREFIX.MATERIAL)}
+            />
+          </FilterSection>
 
-        {/* Shared sections */}
+          <FilterSection icon={<Flash size={16} />} label="Power Requirement">
+            <DualRangeSlider
+              min={0}
+              max={2000}
+              step={50}
+              unit="W"
+              valueLow={powerRange[0]}
+              valueHigh={powerRange[1]}
+              onChange={(low, high) => setPowerRange([low, high])}
+            />
+          </FilterSection>
 
-        {/* Location — products and services (not designs) */}
-        {variant !== "designs" && (
-          <FilterSection icon={<LocationStar size={16} />} label="Location" badge={hasActiveLocation ? 1 : undefined}>
+          <FilterSection icon={<Tools size={16} />} label="Repairability">
+            <ToggleSwitch
+              label={t("Repair Info Available")}
+              description={t("Projects with repair and maintenance info")}
+              checked={repairInfo}
+              onChange={checked => {
+                const newTags = checked
+                  ? [...currentTags, REPAIRABILITY_AVAILABLE_TAG]
+                  : currentTags.filter(t => t !== REPAIRABILITY_AVAILABLE_TAG);
+                const query = { ...router.query };
+                if (newTags.length > 0) {
+                  query.tags = newTags.join(",");
+                } else {
+                  delete query.tags;
+                }
+                router.push({ pathname: router.pathname, query }, undefined, { shallow: true });
+              }}
+            />
+          </FilterSection>
+        </>
+      )}
+
+      {/* SERVICES variant */}
+      {variant === "services" && (
+        <>
+          <FilterSection
+            icon={<LocationStar size={16} />}
+            label="Location"
+            defaultOpen
+            badge={hasActiveLocation ? 1 : undefined}
+          >
             <div className="flex flex-col gap-2" ref={locationDropdownRef}>
               {locationLabel ? (
                 <div
@@ -748,97 +598,327 @@ export default function CatalogFilterSidebar({ variant, collapsed = false, onTog
               </div>
             </div>
           </FilterSection>
-        )}
 
-        <FilterSection icon={<Tag size={16} />} label="Categories & Tags">
-          <div className="flex flex-col gap-2 max-h-[216px] overflow-y-auto pr-3">
-            {PRODUCT_CATEGORY_OPTIONS.map((cat: string) => {
-              const active = selectedCategories.includes(cat);
-              return (
+          <FilterSection
+            icon={<Chemistry size={16} />}
+            label="Service Type"
+            defaultOpen
+            badge={selectedServiceTypes.length || undefined}
+          >
+            <CheckboxFilter
+              items={[...SERVICE_TYPE_OPTIONS]}
+              selectedItems={selectedServiceTypes}
+              onToggle={toggleTag(TAG_PREFIX.SERVICE_TYPE)}
+            />
+          </FilterSection>
+
+          <FilterSection
+            icon={<Time size={16} />}
+            label="Availability"
+            badge={selectedAvailability.length || undefined}
+          >
+            <CheckboxFilter
+              items={[...AVAILABILITY_OPTIONS]}
+              selectedItems={selectedAvailability}
+              onToggle={toggleTag(TAG_PREFIX.AVAILABILITY)}
+            />
+          </FilterSection>
+
+          <FilterSection
+            icon={<Settings size={16} />}
+            label="Machines Available"
+            badge={selectedMachines.length || undefined}
+          >
+            <CheckboxFilter
+              items={MACHINES}
+              searchPlaceholder="Search machines..."
+              selectedItems={selectedMachines}
+              onToggle={toggleTag(TAG_PREFIX.MACHINE)}
+            />
+          </FilterSection>
+        </>
+      )}
+
+      {/* Shared sections */}
+
+      {/* Location — products and services (not designs) */}
+      {variant !== "designs" && (
+        <FilterSection icon={<LocationStar size={16} />} label="Location" badge={hasActiveLocation ? 1 : undefined}>
+          <div className="flex flex-col gap-2" ref={locationDropdownRef}>
+            {locationLabel ? (
+              <div
+                className="flex items-center gap-2 px-3 bg-ifr-active border border-ifr rounded-ifr-sm"
+                style={{ height: "var(--ifr-control-height)" }}
+              >
+                <LocationStar size={14} className="text-ifr-green shrink-0" />
+                <span
+                  className="flex-1 text-ifr-text-primary truncate"
+                  style={{ fontFamily: "var(--ifr-font-body)", fontSize: "var(--ifr-fs-base)" }}
+                >
+                  {locationLabel}
+                </span>
                 <button
-                  key={cat}
                   type="button"
-                  onClick={() => toggleCategory(cat)}
-                  className={`text-left px-3 py-2 rounded-ifr-sm transition-colors cursor-pointer ${
-                    active ? "bg-ifr-active text-ifr-green font-medium" : "hover:bg-ifr-search text-ifr-text-secondary"
-                  }`}
+                  onClick={clearLocation}
+                  className="shrink-0 text-ifr-text-secondary hover:text-ifr-text-primary cursor-pointer"
+                >
+                  <Close size={14} />
+                </button>
+              </div>
+            ) : (
+              <div className="relative">
+                <input
+                  type="text"
+                  value={locationInput}
+                  onChange={e => setLocationInput(e.target.value)}
+                  onFocus={() => locationOptions.length > 0 && setShowLocationDropdown(true)}
+                  placeholder={t("Search city or address...")}
+                  className="w-full px-3 bg-ifr-form-input border border-ifr-form-input rounded-ifr-sm outline-none focus:border-ifr-green"
                   style={{
+                    height: "var(--ifr-control-height)",
                     fontFamily: "var(--ifr-font-body)",
                     fontSize: "var(--ifr-fs-base)",
+                  }}
+                />
+                {showLocationDropdown && locationOptions.length > 0 && (
+                  <div className="absolute z-50 left-0 right-0 mt-1 bg-ifr-surface border border-ifr rounded-ifr-sm shadow-lg max-h-[200px] overflow-y-auto">
+                    {locationOptions.map(loc => (
+                      <button
+                        key={loc.id}
+                        type="button"
+                        className="w-full text-left px-3 py-2 hover:bg-ifr-hover transition-colors cursor-pointer"
+                        style={{ fontFamily: "var(--ifr-font-body)", fontSize: "var(--ifr-fs-sm)" }}
+                        onClick={() => handleLocationSelect(loc)}
+                      >
+                        {loc.title}
+                      </button>
+                    ))}
+                  </div>
+                )}
+                {locationLoading && (
+                  <div className="absolute right-3 top-1/2 -translate-y-1/2">
+                    <div className="w-4 h-4 border-2 border-ifr-green border-t-transparent rounded-full animate-spin" />
+                  </div>
+                )}
+              </div>
+            )}
+            <label
+              className="text-ifr-text-primary mt-2"
+              style={{
+                fontFamily: "var(--ifr-font-body)",
+                fontSize: "var(--ifr-fs-sm)",
+                fontWeight: "var(--ifr-fw-medium)",
+              }}
+            >
+              {t("Search Radius")}
+            </label>
+            <div className="flex flex-wrap gap-2">
+              {[10, 25, 50, 100, 250].map(km => (
+                <button
+                  key={km}
+                  type="button"
+                  onClick={() => handleRadiusChange(km)}
+                  className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
+                    searchRadius === km
+                      ? "bg-[#036a53] text-white"
+                      : "border border-[#c9cccf] text-[#0b1324] hover:bg-ifr-hover"
+                  }`}
+                >
+                  {km}
+                  {t("km")}
+                </button>
+              ))}
+            </div>
+          </div>
+        </FilterSection>
+      )}
+
+      <FilterSection icon={<Tag size={16} />} label="Categories & Tags">
+        <div className="flex flex-col gap-2 max-h-[216px] overflow-y-auto pr-3">
+          {PRODUCT_CATEGORY_OPTIONS.map((cat: string) => {
+            const active = selectedCategories.includes(cat);
+            return (
+              <button
+                key={cat}
+                type="button"
+                onClick={() => toggleCategory(cat)}
+                className={`text-left px-3 py-2 rounded-ifr-sm transition-colors cursor-pointer ${
+                  active ? "bg-ifr-active text-ifr-green font-medium" : "hover:bg-ifr-search text-ifr-text-secondary"
+                }`}
+                style={{
+                  fontFamily: "var(--ifr-font-body)",
+                  fontSize: "var(--ifr-fs-base)",
+                  fontWeight: "var(--ifr-fw-medium)",
+                }}
+              >
+                {active ? "✓ " : "+ "}
+                {cat}
+              </button>
+            );
+          })}
+        </div>
+      </FilterSection>
+
+      {/* Power/Environmental — designs and products */}
+      {variant !== "services" && (
+        <>
+          <FilterSection
+            icon={<Flash size={16} />}
+            label="Power Compatibility"
+            badge={selectedPower.length || undefined}
+          >
+            <CheckboxFilter
+              items={variant === "designs" ? [...DESIGN_POWER_SOURCE_OPTIONS] : [...POWER_COMPATIBILITY_OPTIONS]}
+              selectedItems={selectedPower}
+              onToggle={toggleTag(TAG_PREFIX.POWER_COMPAT)}
+            />
+          </FilterSection>
+
+          <FilterSection icon={<Recycle size={16} />} label="Environmental Impact">
+            <div className="flex flex-col gap-4">
+              <div className="flex flex-col gap-1">
+                <span
+                  className="text-ifr-text-primary"
+                  style={{
+                    fontFamily: "var(--ifr-font-body)",
+                    fontSize: "var(--ifr-fs-sm)",
                     fontWeight: "var(--ifr-fw-medium)",
                   }}
                 >
-                  {active ? "✓ " : "+ "}
-                  {cat}
-                </button>
-              );
-            })}
-          </div>
-        </FilterSection>
-
-        {/* Power/Environmental — designs and products */}
-        {variant !== "services" && (
-          <>
-            <FilterSection
-              icon={<Flash size={16} />}
-              label="Power Compatibility"
-              badge={selectedPower.length || undefined}
-            >
-              <CheckboxFilter
-                items={variant === "designs" ? [...DESIGN_POWER_SOURCE_OPTIONS] : [...POWER_COMPATIBILITY_OPTIONS]}
-                selectedItems={selectedPower}
-                onToggle={toggleTag(TAG_PREFIX.POWER_COMPAT)}
-              />
-            </FilterSection>
-
-            <FilterSection icon={<Recycle size={16} />} label="Environmental Impact">
-              <div className="flex flex-col gap-4">
-                <div className="flex flex-col gap-1">
-                  <span
-                    className="text-ifr-text-primary"
-                    style={{
-                      fontFamily: "var(--ifr-font-body)",
-                      fontSize: "var(--ifr-fs-sm)",
-                      fontWeight: "var(--ifr-fw-medium)",
-                    }}
-                  >
-                    {t("CO\u2082 Emissions")}
-                  </span>
-                  <DualRangeSlider
-                    min={0}
-                    max={500}
-                    step={10}
-                    unit="kg"
-                    valueLow={co2Range[0]}
-                    valueHigh={co2Range[1]}
-                    onChange={(low, high) => setCo2Range([low, high])}
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <span
-                    className="text-ifr-text-primary"
-                    style={{
-                      fontFamily: "var(--ifr-font-body)",
-                      fontSize: "var(--ifr-fs-sm)",
-                      fontWeight: "var(--ifr-fw-medium)",
-                    }}
-                  >
-                    {t("Energy Consumption")}
-                  </span>
-                  <DualRangeSlider
-                    min={0}
-                    max={1000}
-                    step={10}
-                    unit="kWh"
-                    valueLow={energyRange[0]}
-                    valueHigh={energyRange[1]}
-                    onChange={(low, high) => setEnergyRange([low, high])}
-                  />
-                </div>
+                  {t("CO\u2082 Emissions")}
+                </span>
+                <DualRangeSlider
+                  min={0}
+                  max={500}
+                  step={10}
+                  unit="kg"
+                  valueLow={co2Range[0]}
+                  valueHigh={co2Range[1]}
+                  onChange={(low, high) => setCo2Range([low, high])}
+                />
               </div>
-            </FilterSection>
-          </>
+              <div className="flex flex-col gap-1">
+                <span
+                  className="text-ifr-text-primary"
+                  style={{
+                    fontFamily: "var(--ifr-font-body)",
+                    fontSize: "var(--ifr-fs-sm)",
+                    fontWeight: "var(--ifr-fw-medium)",
+                  }}
+                >
+                  {t("Energy Consumption")}
+                </span>
+                <DualRangeSlider
+                  min={0}
+                  max={1000}
+                  step={10}
+                  unit="kWh"
+                  valueLow={energyRange[0]}
+                  valueHigh={energyRange[1]}
+                  onChange={(low, high) => setEnergyRange([low, high])}
+                />
+              </div>
+            </div>
+          </FilterSection>
+        </>
+      )}
+    </>
+  );
+
+  // Shared by both presentations — the panel content never changes, only its frame.
+  const header = (
+    <div className="border-b border-ifr px-6 py-4 flex items-center justify-between gap-3 shrink-0">
+      <p
+        className="text-ifr-text-primary"
+        style={{
+          fontFamily: "var(--ifr-font-body)",
+          fontSize: "var(--ifr-fs-md)",
+          fontWeight: "var(--ifr-fw-regular)",
+        }}
+      >
+        {t("Filter by")}
+      </p>
+      <div className="flex items-center gap-3">
+        {hasActiveFilters && (
+          <button
+            type="button"
+            onClick={clearAllFilters}
+            className="text-ifr-text-secondary hover:text-ifr-text-primary text-ifr-sm underline transition-colors cursor-pointer"
+            style={{
+              fontFamily: "var(--ifr-font-body)",
+              fontSize: "var(--ifr-fs-sm)",
+              fontWeight: "var(--ifr-fw-medium)",
+            }}
+          >
+            {t("Reset")}
+          </button>
         )}
+        {asDrawer && (
+          <button
+            type="button"
+            onClick={onToggle}
+            aria-label={t("Close filters")}
+            className="flex items-center justify-center -mr-2 text-ifr-text-secondary hover:text-ifr-text-primary transition-colors cursor-pointer bg-transparent border-none"
+            style={{ width: "var(--ifr-control-height)", height: "var(--ifr-control-height)" }}
+          >
+            <Close size={20} />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+
+  if (asDrawer) {
+    return (
+      <>
+        {drawerOpen && (
+          <div className="fixed inset-0 z-[60] bg-[var(--ifr-overlay-dark)]" onClick={onToggle} aria-hidden="true" />
+        )}
+        <aside
+          className="fixed top-0 left-0 bottom-0 z-[70] bg-ifr-surface flex flex-col"
+          style={{
+            width: "min(var(--ifr-sidebar-width), calc(100vw - 40px))",
+            paddingTop: "env(safe-area-inset-top)",
+            paddingBottom: "env(safe-area-inset-bottom)",
+            transform: drawerOpen ? "translateX(0)" : "translateX(-100%)",
+            transition: "transform 250ms ease",
+            boxShadow: drawerOpen ? "var(--ifr-shadow-dropdown)" : "none",
+            overscrollBehavior: "contain",
+          }}
+          aria-hidden={!drawerOpen}
+        >
+          {header}
+          <div className="flex-1 overflow-y-auto">{sections}</div>
+        </aside>
+      </>
+    );
+  }
+
+  return (
+    <div
+      className="bg-ifr-surface border-r border-ifr shrink-0 relative sticky self-start"
+      style={{
+        width: collapsed ? "0px" : "var(--ifr-sidebar-width)",
+        overflow: "hidden",
+        transition: "width 250ms ease",
+        borderRightWidth: collapsed ? "0px" : undefined,
+        top: "var(--ifr-topbar-height)",
+        maxHeight: "calc(100vh - var(--ifr-topbar-height))",
+      }}
+    >
+      <div
+        className="overflow-y-auto"
+        style={{
+          width: "var(--ifr-sidebar-width)",
+          maxHeight: "calc(100vh - var(--ifr-topbar-height))",
+          opacity: collapsed ? 0 : 1,
+          transition: "opacity 200ms ease",
+          pointerEvents: collapsed ? "none" : undefined,
+        }}
+      >
+        {header}
+
+        {sections}
       </div>
     </div>
   );

--- a/components/CatalogLayout.tsx
+++ b/components/CatalogLayout.tsx
@@ -20,6 +20,7 @@ import {
 } from "lib/types";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
+import { useIsDesktop } from "hooks/useMediaQuery";
 import React, { ReactNode, useState } from "react";
 
 interface CatalogHeroProps {
@@ -49,7 +50,13 @@ export default function CatalogLayout({
 }: CatalogLayoutProps) {
   const { t } = useTranslation("common");
   const router = useRouter();
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const isDesktop = useIsDesktop();
+  // The filter panel starts open as a desktop column but closed as a mobile
+  // drawer — an overlay that covers the results on arrival would be hostile.
+  const [desktopCollapsed, setDesktopCollapsed] = useState(false);
+  const [drawerCollapsed, setDrawerCollapsed] = useState(true);
+  const sidebarCollapsed = isDesktop ? desktopCollapsed : drawerCollapsed;
+  const toggleSidebar = () => (isDesktop ? setDesktopCollapsed(v => !v) : setDrawerCollapsed(v => !v));
   const [searchQuery, setSearchQuery] = useState((router.query.q as string) || "");
 
   const sortBy = (router.query.sort as string) || "Latest";
@@ -137,56 +144,55 @@ export default function CatalogLayout({
   };
 
   return (
-    <div className="flex flex-1 items-start">
-      {/* Filter Sidebar */}
+    <div className="flex flex-1 items-start min-w-0">
+      {/* Filter Sidebar — inline column on desktop, overlay drawer below `lg` */}
       <CatalogFilterSidebar
         variant={variant}
         collapsed={sidebarCollapsed}
-        onToggle={() => setSidebarCollapsed(v => !v)}
+        onToggle={toggleSidebar}
+        asDrawer={!isDesktop}
       />
 
       {/* Main Content */}
-      <div className="flex-1 flex flex-col overflow-y-auto">
+      <div className="flex-1 min-w-0 flex flex-col overflow-y-auto">
         {/* Hero Section */}
         <div className="relative border-b border-ifr" style={{ background: heroGradients[variant] }}>
-          <div className="relative px-6 py-10">
-            <div className="relative z-10 flex items-center gap-6">
+          <div className="relative px-4 py-6 md:px-6 md:py-10">
+            <div className="relative z-10 flex flex-col lg:flex-row lg:items-center gap-5 lg:gap-6">
               {/* Left: Title + Description */}
-              <div className="flex-1 flex flex-col gap-2">
+              <div className="flex-1 min-w-0 flex flex-col gap-2">
                 <h1
-                  className="m-0"
+                  className="m-0 text-[24px] leading-[30px] md:text-[30px] md:leading-[36px]"
                   style={{
                     fontFamily: "var(--ifr-font-heading)",
-                    fontSize: "30px",
                     fontWeight: 700,
-                    lineHeight: "36px",
                     color: "#ffffff",
                   }}
                 >
                   {hero.title}
                 </h1>
                 <p
-                  className="m-0 max-w-[640px]"
-                  style={{ fontFamily: "var(--ifr-font-body)", fontSize: "16px", lineHeight: "24px", color: "#fafafa" }}
+                  className="m-0 max-w-[640px] text-[15px] leading-[22px] md:text-[16px] md:leading-[24px]"
+                  style={{ fontFamily: "var(--ifr-font-body)", color: "#fafafa" }}
                 >
                   {hero.description}
                 </p>
               </div>
 
-              {/* Right: Stats */}
-              <div className="flex gap-[15px] shrink-0">{hero.stats}</div>
+              {/* Right: Stats — wrap rather than overflow on narrow screens */}
+              <div className="flex flex-wrap gap-[10px] md:gap-[15px] lg:shrink-0">{hero.stats}</div>
             </div>
           </div>
         </div>
 
         {/* Search & Sort Bar */}
-        <div className="bg-ifr-surface border-b border-ifr px-6 py-5">
-          <div className="flex items-center justify-between gap-6">
+        <div className="bg-ifr-surface border-b border-ifr px-4 md:px-6 py-4 md:py-5">
+          <div className="flex flex-wrap items-center justify-between gap-3 md:gap-6">
             {/* Filters toggle */}
             <button
               type="button"
-              onClick={() => setSidebarCollapsed(v => !v)}
-              className={`flex items-center gap-[8px] px-3 shrink-0 border transition-colors cursor-pointer ${
+              onClick={toggleSidebar}
+              className={`order-1 flex items-center gap-[8px] px-3 shrink-0 border transition-colors cursor-pointer ${
                 !sidebarCollapsed
                   ? "bg-ifr-hover border-ifr text-ifr-text-primary"
                   : "bg-ifr-surface border-transparent text-ifr-text-secondary hover:border-ifr hover:text-ifr-text-primary"
@@ -207,30 +213,33 @@ export default function CatalogLayout({
               </span>
             </button>
 
-            {/* Search */}
-            <form onSubmit={handleSearch} className="flex-1 max-w-[845px] relative">
-              <div className="bg-ifr-search border border-ifr rounded-full px-4 py-3 flex items-center gap-3">
-                <SearchIcon className="w-5 h-5 text-ifr-text-secondary" />
+            {/* Search — drops to its own full-width row once the toolbar runs out of space */}
+            <form
+              onSubmit={handleSearch}
+              className="order-3 md:order-2 w-full md:w-auto md:flex-1 max-w-[845px] relative"
+            >
+              <div className="bg-ifr-search border border-ifr rounded-full px-4 py-2.5 md:py-3 flex items-center gap-3">
+                <SearchIcon className="w-5 h-5 shrink-0 text-ifr-text-secondary" />
                 <input
-                  type="text"
+                  type="search"
                   placeholder={searchPlaceholder}
                   value={searchQuery}
                   onChange={e => setSearchQuery(e.target.value)}
-                  className="flex-1 bg-transparent text-ifr-text-primary placeholder:text-ifr-text-muted outline-none"
-                  style={{ fontFamily: "var(--ifr-font-body)", fontSize: "var(--ifr-fs-base)", lineHeight: "21px" }}
+                  className="flex-1 min-w-0 bg-transparent text-ifr-text-primary placeholder:text-ifr-text-muted outline-none"
+                  style={{ fontFamily: "var(--ifr-font-body)", lineHeight: "21px" }}
                 />
               </div>
             </form>
 
             {/* Sort */}
-            <div className="flex items-center gap-3 shrink-0">
+            <div className="order-2 md:order-3 flex items-center gap-3 shrink-0">
               <ToolbarDropdown label={t("Sort by")} value={sortBy} options={sortOptions} onChange={handleSortChange} />
             </div>
           </div>
         </div>
 
         {/* Results */}
-        <div className="bg-ifr-results flex-1 p-6">
+        <div className="bg-ifr-results flex-1 p-4 md:p-6">
           {/* Results count */}
           <p
             className="text-ifr-text-secondary"
@@ -253,7 +262,7 @@ export default function CatalogLayout({
             <div
               className="grid justify-center"
               style={{
-                gridTemplateColumns: "repeat(auto-fill, minmax(var(--ifr-card-min-width), var(--ifr-card-max-width)))",
+                gridTemplateColumns: "repeat(auto-fill, var(--ifr-card-track))",
                 gap: "var(--ifr-grid-gap)",
               }}
             >
@@ -295,8 +304,7 @@ export default function CatalogLayout({
               <div
                 className="grid justify-center"
                 style={{
-                  gridTemplateColumns:
-                    "repeat(auto-fill, minmax(var(--ifr-card-min-width), var(--ifr-card-max-width)))",
+                  gridTemplateColumns: "repeat(auto-fill, var(--ifr-card-track))",
                   gap: "var(--ifr-grid-gap)",
                 }}
               >
@@ -335,9 +343,13 @@ export default function CatalogLayout({
 export function HeroStatCard({ value, label }: { icon?: ReactNode; value: string | number; label: string }) {
   return (
     <div
-      className="flex flex-col justify-center"
+      className="flex flex-col justify-center flex-1 lg:flex-none"
       style={{
-        width: 140,
+        // Two cards still fit side by side on a 320px screen; wider viewports
+        // settle back to the fixed prototype width.
+        flexBasis: 130,
+        minWidth: 130,
+        maxWidth: 140,
         height: 56,
         padding: "10px 14px",
         borderRadius: "6px",

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -7,9 +7,9 @@ const Footer = () => {
 
   return (
     <div className="border-t-1 border-t-border-subdued bg-white">
-      <div className="container mx-auto">
+      <div className="container mx-auto px-4 md:px-6">
         <div className="grid grid-cols-1 gap-8 lg:grid-cols-9 py-8 lg:py-12 bg-white">
-          <div className="col-span-4 max-w-sm text-primary lg:place-self-end pr-12">
+          <div className="col-span-4 max-w-sm text-primary lg:place-self-end lg:pr-12">
             <Stack vertical>
               <div className="logo h-16 w-20"></div>
               <Text as={"h1"} variant={"headingLg"}>
@@ -18,7 +18,7 @@ const Footer = () => {
             </Stack>
           </div>
 
-          <div className="flex font-bold col-span-5 justify-between lg:justify-evenly">
+          <div className="flex flex-wrap gap-8 font-bold col-span-5 justify-between lg:justify-evenly">
             <Stack vertical spacing="loose">
               <Text as="h3" variant="headingLg">
                 {t("Projects")}
@@ -97,7 +97,7 @@ const Footer = () => {
         </div>
       </div>
       <div>
-        <div className=" flex flex-col items-start space-y-6 md:flex-row md:items-center md:justify-center md:space-x-6 md:space-y-0 border border-subdued p-8">
+        <div className="flex flex-col items-start gap-6 md:flex-row md:flex-wrap md:items-center md:justify-center border border-subdued p-6 md:p-8">
           <div className="flex items-center space-x-2">
             <Text as="p" variant="bodySm">
               {t("Software by")}
@@ -109,7 +109,7 @@ const Footer = () => {
             </NextLink>
           </div>
 
-          <div className="max-w-[250px] md:pl-4">
+          <div className="max-w-[250px]">
             <Text as="p" variant="bodySm">
               {t("Project funded")}{" "}
               <a

--- a/components/NavigationMenu.tsx
+++ b/components/NavigationMenu.tsx
@@ -20,7 +20,7 @@ import { useAuth } from "hooks/useAuth";
 import { useInBoxContext } from "hooks/useInBox";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 /* ── Reusable sub-components ── */
 
@@ -194,6 +194,26 @@ export default function NavigationMenu({ open, onClose }: NavigationMenuProps) {
   };
   const isProfileDefault = user ? router.asPath === user.profileUrl : false;
 
+  // Lock the page behind the drawer so touch scrolling stays inside it.
+  useEffect(() => {
+    if (!open) return;
+    const previous = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previous;
+    };
+  }, [open]);
+
+  // Escape closes the drawer, matching the backdrop tap.
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open, onClose]);
+
   const iconColor = (active: boolean) => (active ? "var(--ifr-text-primary)" : "var(--ifr-text-secondary)");
   const entityIconColor = (path: string, entityColor: string) =>
     isActive(path) ? entityColor : "var(--ifr-text-secondary)";
@@ -210,10 +230,17 @@ export default function NavigationMenu({ open, onClose }: NavigationMenuProps) {
         className="fixed top-0 left-0 bottom-0 z-[70] bg-[var(--ifr-bg-surface)] flex flex-col"
         style={{
           width: "var(--ifr-nav-menu-width)",
+          // Always leave a strip of backdrop to tap on the narrowest phones
+          maxWidth: "calc(100vw - 40px)",
+          paddingTop: "env(safe-area-inset-top)",
+          paddingLeft: "env(safe-area-inset-left)",
+          paddingBottom: "env(safe-area-inset-bottom)",
           transform: open ? "translateX(0)" : "translateX(-100%)",
           transition: "transform 250ms ease",
           boxShadow: open ? "var(--ifr-shadow-dropdown)" : "none",
+          overscrollBehavior: "contain",
         }}
+        aria-hidden={!open}
       >
         {/* Logo header */}
         <div className="px-6 pt-5 pb-4">

--- a/components/ProfilePageNew.tsx
+++ b/components/ProfilePageNew.tsx
@@ -594,10 +594,7 @@ function DppsTabContent({ userId, isOwner, ctaConfig }: { userId: string; isOwne
           </div>
 
           {/* KPI Stats right */}
-          <div
-            className="grid grid-cols-2 gap-px border border-ifr rounded-ifr-md overflow-hidden shrink-0"
-            style={{ width: "320px" }}
-          >
+          <div className="grid grid-cols-2 gap-px border border-ifr rounded-ifr-md overflow-hidden w-full md:w-[320px] md:shrink-0">
             {(
               [
                 { label: "Total DPPs", value: statusCounts.total },
@@ -1096,19 +1093,19 @@ export default function ProfilePageNew() {
 
   return (
     <div className="flex-1 bg-ifr-page" style={{ fontFamily: "var(--ifr-font-body)" }}>
-      <div className="max-w-[1280px] mx-auto px-6 py-8">
+      <div className="max-w-[1280px] mx-auto px-4 md:px-6 py-6 md:py-8">
         {/* Profile Header */}
         <div className="flex flex-col md:flex-row gap-6 mb-8">
           {/* Avatar */}
           <div className="shrink-0">
-            <div className="rounded-full overflow-hidden border border-ifr" style={{ width: "120px", height: "120px" }}>
-              <BrUserAvatar userId={id} size="120px" />
+            <div className="rounded-full overflow-hidden border border-ifr w-20 h-20 md:w-[120px] md:h-[120px]">
+              <BrUserAvatar userId={id} size="100%" />
             </div>
           </div>
 
           {/* Info */}
           <div className="flex-1 min-w-0">
-            <div className="flex items-start justify-between gap-4">
+            <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
               <div className="flex flex-col gap-2 min-w-0">
                 {/* Name + verified */}
                 <div className="flex items-center gap-2">

--- a/components/ProjectDetailNew.tsx
+++ b/components/ProjectDetailNew.tsx
@@ -92,15 +92,15 @@ function ProjectSidebarNew({ project, projectType, sidebarRating }: ProjectSideb
 
   return (
     <div className="w-full lg:w-[300px] shrink-0 h-full">
+      {/* Sticks alongside the article on desktop; below `lg` it is a normal
+          block in the flow, so it must not cap its own height or scroll. */}
       <div
-        className="sticky flex flex-col"
+        className="flex flex-col lg:sticky lg:max-h-[calc(100vh-var(--ifr-topbar-height)-32px)] lg:overflow-y-auto"
         style={{
           top: "calc(var(--ifr-topbar-height) + 16px)",
           border: "1px solid #c9cccf",
           borderRadius: "4px",
           backgroundColor: "#fff",
-          maxHeight: "calc(100vh - var(--ifr-topbar-height) - 32px)",
-          overflowY: "auto",
         }}
       >
         {/* Title */}
@@ -684,14 +684,13 @@ function TagBadgeDetail({ text }: { text: string }) {
 function DppFieldRow({ label, value }: { label: string; value?: string }) {
   if (!value) return null;
   return (
-    <div className="flex items-start gap-3 w-full">
+    <div className="flex flex-col sm:flex-row items-start gap-1 sm:gap-3 w-full">
       <span
-        className="text-ifr-text-secondary shrink-0"
+        className="text-ifr-text-secondary sm:shrink-0 sm:w-[180px]"
         style={{
           fontFamily: "var(--ifr-font-body)",
           fontSize: "var(--ifr-fs-base)",
           lineHeight: "24px",
-          width: "180px",
         }}
       >
         {label}
@@ -845,7 +844,7 @@ function SustainabilityMetrics({ dpp }: { dpp: Record<string, string> }) {
   if (metrics.length === 0) return null;
 
   return (
-    <div className="grid grid-cols-2 gap-4">
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
       {metrics.map(m => (
         <MetricCard key={m.label} icon={m.icon} iconBg={m.iconBg} label={m.label} value={m.value} unit={m.unit} />
       ))}
@@ -1430,7 +1429,7 @@ export default function ProjectDetailNew() {
 
   return (
     <div className="flex-1 bg-ifr-page" style={{ fontFamily: "var(--ifr-font-body)" }}>
-      <div className="max-w-[1280px] mx-auto px-6 py-8 flex gap-8">
+      <div className="max-w-[1280px] mx-auto px-4 md:px-6 py-6 md:py-8 flex gap-8">
         {/* Main content */}
         <div className="flex-1 min-w-0 flex flex-col gap-4">
           {/* Breadcrumb */}
@@ -1445,7 +1444,7 @@ export default function ProjectDetailNew() {
           </nav>
 
           {/* Header */}
-          <div className="flex items-start justify-between">
+          <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
             <div className="flex flex-col gap-2 flex-1 min-w-0">
               {/* Type badge + ID */}
               <div className="flex items-center gap-2">
@@ -2322,7 +2321,7 @@ export default function ProjectDetailNew() {
       </div>
 
       {/* Mobile sidebar */}
-      <div className="lg:hidden px-6 pb-8">
+      <div className="lg:hidden px-4 md:px-6 pb-8">
         <ProjectSidebarNew project={project} projectType={projectType} sidebarRating={sidebarRating} />
       </div>
     </div>

--- a/components/ResourcesCards.tsx
+++ b/components/ResourcesCards.tsx
@@ -97,7 +97,7 @@ const ResourcesCards = (props: ResourcesCardsProps) => {
               ]}
             >
               <img src={e.node.metadata?.image} className="w-20 h-20" alt={e.node.name} />
-              <p className="w-64">{e.node.note}</p>
+              <p className="w-full max-w-xs">{e.node.note}</p>
             </Card>
           </>
         ))}

--- a/components/brickroom/BrTable.tsx
+++ b/components/brickroom/BrTable.tsx
@@ -25,8 +25,10 @@ type BrTableProps = {
 const BrTable = ({ headArray, children, emptyState = "0 results" }: BrTableProps) => {
   return (
     <>
-      <div className="overflow-x-auto rounded-box">
-        <div className="table w-full rounded-box">
+      {/* Below ~720px the columns would crush into unreadable slivers, so the
+          table keeps its width and scrolls sideways inside this box instead. */}
+      <div className="overflow-x-auto overscroll-x-contain rounded-box">
+        <div className="table w-full min-w-[720px] rounded-box">
           {/* The header */}
           <div className="table-header-group bg-white-100">
             <div className="table-row">

--- a/components/layout/WithFilterLayout.tsx
+++ b/components/layout/WithFilterLayout.tsx
@@ -28,7 +28,7 @@ const WithFilterLayout = ({
   return (
     <>
       <div className="flex flex-col">
-        <div className="flex items-center justify-between py-5">
+        <div className="flex flex-wrap items-center justify-between gap-3 py-5">
           {header ? <PTitleCounter title={header} titleTag="h2" length={length} /> : <div />}
           {!hideFilters && (
             <Button
@@ -41,10 +41,12 @@ const WithFilterLayout = ({
             </Button>
           )}
         </div>
-        <div className="flex flex-row flex-nowrap items-start space-x-8 w-full">
-          {children}
+        {/* Filters sit beside the results only where there is room for both;
+            below `lg` they open above the list instead of squeezing it. */}
+        <div className="flex flex-col-reverse lg:flex-row lg:flex-nowrap items-stretch lg:items-start gap-6 lg:gap-0 lg:space-x-8 w-full min-w-0">
+          <div className="flex-1 min-w-0">{children}</div>
           {!hideFilters && showFilter && (
-            <div className="basis-96 sticky top-8">
+            <div className="w-full lg:w-auto lg:basis-96 lg:shrink-0 lg:sticky lg:top-8">
               <ProjectsFilters hidePrimaryAccountable={hidePrimaryAccountable} hideConformsTo={hideConformsTo} />
             </div>
           )}

--- a/components/partials/create/dpp/CreateDppForm.tsx
+++ b/components/partials/create/dpp/CreateDppForm.tsx
@@ -111,9 +111,12 @@ function CreateDppNav() {
   }, []);
 
   return (
-    <nav className="bg-ifr-surface border border-ifr rounded-ifr-md p-4 flex flex-col gap-1" aria-label={t("Sections")}>
+    <nav
+      className="bg-ifr-surface border border-ifr rounded-ifr-md p-3 lg:p-4 flex flex-row lg:flex-col items-center lg:items-stretch gap-2 lg:gap-1 overflow-x-auto lg:overflow-visible overscroll-x-contain"
+      aria-label={t("Sections")}
+    >
       <p
-        className="text-ifr-text-secondary m-0 mb-2 px-3"
+        className="hidden lg:block text-ifr-text-secondary m-0 mb-2 px-3"
         style={{
           fontFamily: "var(--ifr-font-body)",
           fontSize: "var(--ifr-fs-sm)",
@@ -131,7 +134,7 @@ function CreateDppNav() {
             key={section.id}
             type="button"
             onClick={() => scrollTo(section.id)}
-            className={`text-left px-3 py-2 border-none cursor-pointer transition-colors rounded-sm ${
+            className={`text-left shrink-0 whitespace-nowrap px-3 py-2 border-none cursor-pointer transition-colors rounded-sm ${
               isActive ? "bg-ifr-hover" : "bg-transparent hover:bg-ifr-hover/50"
             }`}
             style={{
@@ -268,16 +271,16 @@ export default function CreateDppForm() {
     <FormProvider {...formMethods}>
       <form onSubmit={handleSubmit(onSubmit)}>
         <div className="flex flex-col min-h-screen bg-ifr-page" style={{ fontFamily: "var(--ifr-font-body)" }}>
-          <div className="flex-1 flex flex-row justify-center gap-8 lg:gap-12 p-6 max-w-[1280px] mx-auto w-full">
-            {/* Sidebar Nav */}
-            <div className="hidden lg:block w-[260px] shrink-0">
-              <div className="sticky top-24">
+          <div className="flex-1 flex flex-col lg:flex-row lg:justify-center gap-6 lg:gap-12 p-4 md:p-6 max-w-[1280px] mx-auto w-full">
+            {/* Sidebar Nav — sticky rail on desktop, jump strip on phones */}
+            <div className="lg:w-[260px] lg:shrink-0">
+              <div className="lg:sticky lg:top-24">
                 <CreateDppNav />
               </div>
             </div>
 
             {/* Main Content */}
-            <div className="flex-1 max-w-2xl pb-24">
+            <div className="flex-1 min-w-0 max-w-2xl pb-24">
               <div className="flex flex-col gap-6">
                 {/* Header */}
                 <div className="bg-ifr-surface border border-ifr rounded-ifr-md py-8 px-8">
@@ -756,7 +759,10 @@ export default function CreateDppForm() {
             className="sticky bottom-0 right-0 z-30 border-t border-ifr"
             style={{ backgroundColor: "var(--ifr-bg-surface)", fontFamily: "var(--ifr-font-body)" }}
           >
-            <div className="max-w-[1280px] mx-auto flex flex-row items-center justify-end gap-3 px-6 py-3">
+            <div
+              className="max-w-[1280px] mx-auto flex flex-wrap items-center justify-end gap-2 md:gap-3 px-4 md:px-6 py-3"
+              style={{ paddingBottom: "max(0.75rem, env(safe-area-inset-bottom))" }}
+            >
               <button
                 type="button"
                 onClick={() => router.back()}

--- a/components/partials/create/project/CreateProjectForm.tsx
+++ b/components/partials/create/project/CreateProjectForm.tsx
@@ -234,9 +234,9 @@ export default function CreateProjectForm(props: Props) {
       <ProjectTypeContext.Provider value={projectType}>
         <form onSubmit={handleSubmit(onSubmit)}>
           <div className="flex flex-col min-h-screen bg-ifr-page" style={{ fontFamily: "var(--ifr-font-body)" }}>
-            <div className="flex-1 flex flex-row justify-center gap-8 lg:gap-12 p-6 lg:p-10 max-w-[1440px] mx-auto w-full">
-              <div className="hidden lg:block w-[300px] shrink-0">
-                <div className="sticky top-24">
+            <div className="flex-1 flex flex-col lg:flex-row lg:justify-center gap-6 lg:gap-12 p-4 md:p-6 lg:p-10 max-w-[1440px] mx-auto w-full">
+              <div className="lg:w-[300px] lg:shrink-0">
+                <div className="lg:sticky lg:top-24">
                   <CreateProjectNav projectType={projectType} />
                 </div>
               </div>

--- a/components/partials/create/project/parts/CreateProjectFields.tsx
+++ b/components/partials/create/project/parts/CreateProjectFields.tsx
@@ -87,7 +87,7 @@ export default function CreateProjectFields(props: Props) {
       {sections.map((section, index) => (
         <div key={index}>
           <div id={section.id} className="scroll-mt-24" />
-          <div className="bg-ifr-surface border border-ifr rounded-ifr-md py-8 px-8">
+          <div className="bg-ifr-surface border border-ifr rounded-ifr-md py-6 px-4 md:py-8 md:px-8">
             <div className="flex flex-col gap-6">{section.component}</div>
           </div>
         </div>

--- a/components/partials/create/project/parts/CreateProjectNav.tsx
+++ b/components/partials/create/project/parts/CreateProjectNav.tsx
@@ -43,9 +43,11 @@ export default function CreateProjectNav(props: Props) {
   }, []);
 
   return (
+    // A long form needs its jump list on a phone more than on a desktop, so
+    // instead of dropping it the rail lies down into a scrollable strip.
     <nav
-      className="bg-ifr-surface border border-ifr flex flex-col gap-2"
-      style={{ borderRadius: "var(--ifr-radius-md)", padding: "24px" }}
+      className="bg-ifr-surface border border-ifr flex flex-row lg:flex-col gap-3 lg:gap-2 overflow-x-auto lg:overflow-visible overscroll-x-contain p-3 lg:p-6"
+      style={{ borderRadius: "var(--ifr-radius-md)" }}
       aria-label={t("Sections")}
     >
       {sections
@@ -59,13 +61,12 @@ export default function CreateProjectNav(props: Props) {
               key={section.id}
               type="button"
               onClick={() => scrollTo(section.id)}
-              className="text-left border-none cursor-pointer transition-colors bg-transparent hover:opacity-70"
+              className="text-left shrink-0 whitespace-nowrap border-none cursor-pointer transition-colors bg-transparent hover:opacity-70 py-1 lg:py-1"
               style={{
                 fontFamily: "var(--ifr-font-body)",
                 fontSize: "var(--ifr-fs-base)",
                 fontWeight: isActive ? "var(--ifr-fw-semibold)" : "var(--ifr-fw-medium)",
                 color: "var(--ifr-text-primary)",
-                padding: "4px 0",
               }}
             >
               {section.navLabelByType?.[projectType] || section.navLabel}

--- a/components/partials/create/project/parts/CreateProjectSubmit.tsx
+++ b/components/partials/create/project/parts/CreateProjectSubmit.tsx
@@ -26,7 +26,10 @@ export default function CreateProjectSubmit() {
         fontFamily: "var(--ifr-font-body)",
       }}
     >
-      <div className="max-w-[1280px] mx-auto flex flex-row items-center justify-end gap-3 px-6 py-3">
+      <div
+        className="max-w-[1280px] mx-auto flex flex-wrap items-center justify-end gap-2 md:gap-3 px-4 md:px-6 py-3"
+        style={{ paddingBottom: "max(0.75rem, env(safe-area-inset-bottom))" }}
+      >
         <DeleteDraftButton />
         <EditDraftButton />
         <SaveDraftButton />

--- a/components/partials/profile/[id]/ProfileHeading.tsx
+++ b/components/partials/profile/[id]/ProfileHeading.tsx
@@ -47,11 +47,13 @@ const ProfileHeading = () => {
           </div>
           <Card sectioned>
             <Stack vertical spacing="extraLoose">
-              <BrUserAvatar user={person} size="300px" />
+              <div className="w-full max-w-[300px] mx-auto">
+                <BrUserAvatar user={person} size="100%" />
+              </div>
               {person?.primaryLocation && (
                 <Stack vertical>
                   <PTitleSubtitle title={t("Location")} titleTag="h2" />
-                  <div className="w-72">
+                  <div className="w-full max-w-xs">
                     <DetailMap height={180} location={person?.primaryLocation} />
                   </div>
                 </Stack>
@@ -65,8 +67,8 @@ const ProfileHeading = () => {
   };
 
   return (
-    <div className="p-4 flex space-x-4">
-      <div className="grow">
+    <div className="p-4 flex min-w-0 lg:space-x-4">
+      <div className="grow min-w-0">
         <Stack vertical spacing="extraLoose">
           <div className="flex flex-row">
             <Stack vertical spacing="extraLoose">
@@ -106,7 +108,7 @@ const ProfileHeading = () => {
           </div>
         </Stack>
       </div>
-      <div className="hidden lg:block w-128">
+      <div className="hidden lg:block w-128 shrink-0">
         <ProfileHeadingSideBar />
       </div>
     </div>

--- a/components/partials/project/edit/EditFormLayout.tsx
+++ b/components/partials/project/edit/EditFormLayout.tsx
@@ -85,12 +85,14 @@ export default function EditFormLayout<T extends FieldValues>(props: EditFormLay
   const content = (
     <FormProvider {...formMethods}>
       <form onSubmit={handleSubmit(onSubmitWrapper)}>
-        <div className="flex justify-center items-start space-x-8 md:space-x-16 lg:space-x-24 p-6">
-          <div className="sticky top-24">
+        {/* Section nav rides above the fields on phones and becomes a sticky
+            rail beside them from `lg` up, where the two fit side by side. */}
+        <div className="flex flex-col lg:flex-row lg:justify-center items-stretch lg:items-start gap-6 lg:gap-0 lg:space-x-16 xl:space-x-24 p-4 md:p-6">
+          <div className="lg:sticky lg:top-24 lg:shrink-0">
             {!nav && <EditProjectNav />}
             {nav}
           </div>
-          <div className="grow max-w-xl px-6 pb-24 pt-0">{children}</div>
+          <div className="grow min-w-0 w-full max-w-xl mx-auto lg:mx-0 px-0 md:px-6 pb-24 pt-0">{children}</div>
         </div>
         <SubmitChangesBar />
       </form>

--- a/components/partials/project/edit/SubmitChangesBar.tsx
+++ b/components/partials/project/edit/SubmitChangesBar.tsx
@@ -17,12 +17,15 @@ export default function SubmitChangesBar(props: SubmitChangesProps) {
   return (
     <>
       {isDirty && (
-        <div className="bg-yellow-100 border-t-1 border-t-border-warning-subdued p-4 flex justify-end items-center space-x-6 sticky bottom-0 z-20">
+        <div
+          className="bg-yellow-100 border-t-1 border-t-border-warning-subdued px-4 py-3 flex flex-wrap justify-end items-center gap-3 sm:gap-6 sticky bottom-0 z-20"
+          style={{ paddingBottom: "max(0.75rem, env(safe-area-inset-bottom))" }}
+        >
           <Text variant="bodyMd" as="p">
             {t("You have unsaved changes")}
           </Text>
 
-          <div className="space-x-2">
+          <div className="flex flex-wrap gap-2">
             <Button onClick={handleReset} icon={<Icon source={CancelMinor} />}>
               {t("Discard changes")}
             </Button>

--- a/components/partials/topbar/Topbar.tsx
+++ b/components/partials/topbar/Topbar.tsx
@@ -44,12 +44,16 @@ function Topbar({ search = true, userMenu = true, cta, burger = true }: topbarPr
 
   const [menuOpen, setMenuOpen] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
+  // Below `md` the search field does not fit beside the logo and the avatar,
+  // so it collapses to an icon that opens a full-width row under the header.
+  const [mobileSearchOpen, setMobileSearchOpen] = useState(false);
 
   // Close menu/dropdown on route change
   useEffect(() => {
     const handleRouteChange = () => {
       setMenuOpen(false);
       setDropdownOpen(false);
+      setMobileSearchOpen(false);
     };
     router.events.on("routeChangeComplete", handleRouteChange);
     return () => router.events.off("routeChangeComplete", handleRouteChange);
@@ -73,19 +77,20 @@ function Topbar({ search = true, userMenu = true, cta, burger = true }: topbarPr
   return (
     <>
       <header
-        className="flex items-center justify-between px-6 bg-[var(--ifr-bg-surface)] border-b border-[var(--ifr-border)] shrink-0 sticky top-0 z-50"
+        className="flex items-center justify-between gap-2 px-4 md:px-6 bg-[var(--ifr-bg-surface)] border-b border-[var(--ifr-border)] shrink-0 sticky top-0 z-50"
         style={{ height: "var(--ifr-topbar-height)", minHeight: "var(--ifr-topbar-height)" }}
       >
         {/* Left section: hamburger + logo + nav */}
-        <div className="flex items-center gap-6">
+        <div className="flex items-center gap-3 md:gap-6 min-w-0">
           {/* Hamburger menu button */}
           {burger && (
             <button
               onClick={() => setMenuOpen(true)}
-              className="flex flex-col items-start justify-center gap-[3px] bg-transparent border border-transparent cursor-pointer hover:border-[var(--ifr-border)] group transition-colors"
+              className="flex flex-col items-start justify-center gap-[3px] shrink-0 bg-transparent border border-transparent cursor-pointer hover:border-[var(--ifr-border)] group transition-colors"
               style={{
                 width: "var(--ifr-control-height)",
                 height: "var(--ifr-control-height)",
+                minWidth: "var(--ifr-control-height)",
                 borderRadius: "var(--ifr-radius-sm)",
                 padding: "0 10px",
               }}
@@ -108,13 +113,14 @@ function Topbar({ search = true, userMenu = true, cta, burger = true }: topbarPr
 
           {/* Logo */}
           <Link href="/">
-            <a className="flex items-center group">
-              <InterfacerLogo className="h-5 w-auto" color="var(--ifr-text-secondary)" />
+            <a className="flex items-center shrink-0 group">
+              <InterfacerLogo className="h-4 md:h-5 w-auto" color="var(--ifr-text-secondary)" />
             </a>
           </Link>
 
-          {/* Navigation links */}
-          <nav className="hidden md:flex items-center gap-6 ml-2">
+          {/* Navigation links — from `lg` only: at 768px they would collide
+              with the search field. Below that the drawer carries them. */}
+          <nav className="hidden lg:flex items-center gap-6 ml-2">
             <Link href="/designs">
               <a
                 className={`no-underline whitespace-nowrap px-3 py-1.5 transition-colors ${
@@ -169,20 +175,15 @@ function Topbar({ search = true, userMenu = true, cta, burger = true }: topbarPr
           </nav>
         </div>
 
-        {/* Center: Search bar */}
+        {/* Center: Search bar — hidden below `md`, where it opens as its own row */}
         {search && (
-          <div className="flex items-center flex-[0_1_400px] mx-4">
+          <div className="hidden md:flex items-center flex-[0_1_400px] ml-6 mr-4">
             <div className="flex items-center gap-2.5 flex-1 bg-[var(--ifr-bg-search)] border border-[var(--ifr-border)] rounded-full px-4 py-2 focus-within:border-[var(--ifr-text-secondary)] transition-colors">
-              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" className="block shrink-0">
-                <path
-                  d="M14.354 13.646L10.924 10.216C11.758 9.226 12.25 7.94 12.25 6.5C12.25 3.048 9.452 0.25 6 0.25C2.548 0.25 -0.25 3.048 -0.25 6.5C-0.25 9.952 2.548 12.75 6 12.75C7.44 12.75 8.726 12.258 9.716 11.424L13.146 14.854L14.354 13.646ZM1.25 6.5C1.25 3.878 3.378 1.75 6 1.75C8.622 1.75 10.75 3.878 10.75 6.5C10.75 9.122 8.622 11.25 6 11.25C3.378 11.25 1.25 9.122 1.25 6.5Z"
-                  fill="var(--ifr-text-secondary)"
-                />
-              </svg>
+              <SearchGlyph />
               <input
                 type="text"
                 placeholder={t("Search designs, manufacturers, projects...")}
-                className="flex-1 bg-transparent border-none outline-none text-[var(--ifr-text-primary)] placeholder:text-[var(--ifr-placeholder)]"
+                className="flex-1 min-w-0 bg-transparent border-none outline-none text-[var(--ifr-text-primary)] placeholder:text-[var(--ifr-placeholder)]"
                 style={{ fontFamily: "var(--ifr-font-body)", fontSize: "var(--ifr-fs-base)" }}
                 value={searchString}
                 onChange={e => setSearchString(e.target.value)}
@@ -193,13 +194,31 @@ function Topbar({ search = true, userMenu = true, cta, burger = true }: topbarPr
         )}
 
         {/* Right section */}
-        <div className="flex items-center gap-4">
+        <div className="flex items-center gap-2 md:gap-4 shrink-0">
+          {/* Mobile search toggle */}
+          {search && (
+            <button
+              type="button"
+              onClick={() => setMobileSearchOpen(v => !v)}
+              className="md:hidden flex items-center justify-center shrink-0 bg-transparent border border-transparent cursor-pointer hover:border-[var(--ifr-border)] transition-colors"
+              style={{
+                width: "var(--ifr-control-height)",
+                height: "var(--ifr-control-height)",
+                borderRadius: "var(--ifr-radius-sm)",
+              }}
+              aria-label={t("Search")}
+              aria-expanded={mobileSearchOpen}
+            >
+              <SearchGlyph />
+            </button>
+          )}
           {cta}
           {/* Sign-in / Sign-up buttons for unauthenticated users */}
           {!user && !isSignin && !isSignup && (
             <div className="flex items-center gap-2">
+              {/* On phones the drawer carries "Sign in"; the bar keeps only the primary action */}
               <button
-                className="px-4 py-1.5 bg-transparent border border-[var(--ifr-border)] cursor-pointer transition-colors hover:bg-[var(--ifr-bg-hover)]"
+                className="hidden sm:block px-4 py-1.5 whitespace-nowrap bg-transparent border border-[var(--ifr-border)] cursor-pointer transition-colors hover:bg-[var(--ifr-bg-hover)]"
                 style={{
                   borderRadius: "var(--ifr-radius-sm)",
                   fontFamily: "var(--ifr-font-body)",
@@ -212,7 +231,7 @@ function Topbar({ search = true, userMenu = true, cta, burger = true }: topbarPr
                 {t("Sign in")}
               </button>
               <button
-                className="px-4 py-1.5 border-none cursor-pointer transition-colors"
+                className="px-3 md:px-4 py-1.5 whitespace-nowrap border-none cursor-pointer transition-colors"
                 style={{
                   borderRadius: "var(--ifr-radius-sm)",
                   fontFamily: "var(--ifr-font-body)",
@@ -229,10 +248,10 @@ function Topbar({ search = true, userMenu = true, cta, burger = true }: topbarPr
           )}
           {(isSignup || isSignin) && (
             <div className="flex space-x-2">
-              <button className="btn btn-primary" onClick={() => router.push("/sign_in")}>
+              <button className="btn btn-sm md:btn-md btn-primary" onClick={() => router.push("/sign_in")}>
                 {t("Login")}
               </button>
-              <button className="btn btn-accent" onClick={() => router.push("/sign_up")}>
+              <button className="btn btn-sm md:btn-md btn-accent" onClick={() => router.push("/sign_up")}>
                 {t("Sign up")}
               </button>
             </div>
@@ -243,7 +262,7 @@ function Topbar({ search = true, userMenu = true, cta, burger = true }: topbarPr
             <div className="relative flex items-center">
               <button
                 onClick={() => setDropdownOpen(!dropdownOpen)}
-                className="relative rounded-full p-0 bg-transparent cursor-pointer overflow-visible hover:ring-2 hover:ring-[var(--ifr-text-secondary)]/30 transition-shadow"
+                className="relative shrink-0 rounded-full p-0 bg-transparent cursor-pointer overflow-visible hover:ring-2 hover:ring-[var(--ifr-text-secondary)]/30 transition-shadow"
                 style={{
                   width: "var(--ifr-avatar-size)",
                   height: "var(--ifr-avatar-size)",
@@ -270,9 +289,42 @@ function Topbar({ search = true, userMenu = true, cta, burger = true }: topbarPr
         </div>
       </header>
 
+      {/* Mobile search row — appears under the bar, full width, on demand */}
+      {search && mobileSearchOpen && (
+        <div
+          className="md:hidden sticky z-40 bg-[var(--ifr-bg-surface)] border-b border-[var(--ifr-border)] px-4 py-2.5"
+          style={{ top: "var(--ifr-topbar-height)" }}
+        >
+          <div className="flex items-center gap-2.5 bg-[var(--ifr-bg-search)] border border-[var(--ifr-border)] rounded-full px-4 py-2 focus-within:border-[var(--ifr-text-secondary)] transition-colors">
+            <SearchGlyph />
+            <input
+              type="search"
+              autoFocus
+              placeholder={t("Search designs, manufacturers, projects...")}
+              className="flex-1 min-w-0 bg-transparent border-none outline-none text-[var(--ifr-text-primary)] placeholder:text-[var(--ifr-placeholder)]"
+              style={{ fontFamily: "var(--ifr-font-body)" }}
+              value={searchString}
+              onChange={e => setSearchString(e.target.value)}
+              onKeyDown={handleSearchKeyDown}
+            />
+          </div>
+        </div>
+      )}
+
       {/* Navigation drawer */}
       <NavigationMenu open={menuOpen} onClose={() => setMenuOpen(false)} />
     </>
+  );
+}
+
+function SearchGlyph() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" className="block shrink-0" aria-hidden="true">
+      <path
+        d="M14.354 13.646L10.924 10.216C11.758 9.226 12.25 7.94 12.25 6.5C12.25 3.048 9.452 0.25 6 0.25C2.548 0.25 -0.25 3.048 -0.25 6.5C-0.25 9.952 2.548 12.75 6 12.75C7.44 12.75 8.726 12.258 9.716 11.424L13.146 14.854L14.354 13.646ZM1.25 6.5C1.25 3.878 3.378 1.75 6 1.75C8.622 1.75 10.75 3.878 10.75 6.5C10.75 9.122 8.622 11.25 6 11.25C3.378 11.25 1.25 9.122 1.25 6.5Z"
+        fill="var(--ifr-text-secondary)"
+      />
+    </svg>
   );
 }
 

--- a/hooks/useMediaQuery.ts
+++ b/hooks/useMediaQuery.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Copyright (C) 2022-2023 Dyne.org foundation <foundation@dyne.org>.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import { useCallback, useSyncExternalStore } from "react";
+
+/**
+ * Subscribe to a CSS media query from React.
+ *
+ * Prefer plain CSS for anything CSS can express. This is for the cases where
+ * the *behaviour* differs, not just the styling — a panel that is an inline
+ * column on desktop and a modal drawer on a phone, where the open/closed
+ * default is not the same on both.
+ *
+ * Server rendering has no viewport, so the server snapshot is always `false`;
+ * React swaps in the real value on hydration without a mismatch warning.
+ */
+export default function useMediaQuery(query: string): boolean {
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      if (typeof window === "undefined" || !window.matchMedia) return () => undefined;
+      const list = window.matchMedia(query);
+      // Safari < 14 only supports the deprecated add/removeListener pair.
+      if (list.addEventListener) {
+        list.addEventListener("change", onChange);
+        return () => list.removeEventListener("change", onChange);
+      }
+      list.addListener(onChange);
+      return () => list.removeListener(onChange);
+    },
+    [query]
+  );
+
+  const getSnapshot = useCallback(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return false;
+    return window.matchMedia(query).matches;
+  }, [query]);
+
+  const getServerSnapshot = useCallback(() => false, []);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}
+
+/** Tailwind's `lg` breakpoint — the point where side-by-side layouts earn their space. */
+export const useIsDesktop = () => useMediaQuery("(min-width: 1024px)");
+
+/** Tailwind's `md` breakpoint. */
+export const useIsTablet = () => useMediaQuery("(min-width: 768px)");

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -27,11 +27,11 @@ const FourOhFour: NextPageWithLayout = () => {
   const { t } = useTranslation("common");
   return (
     <div className="grid h-full grid-cols-6">
-      <div className="col-span-6 p-2 md:col-span-4 md:col-start-2 md:col-end-6">
-        <div className="w-full h-full pt-56">
+      <div className="col-span-6 px-4 py-2 md:col-span-4 md:col-start-2 md:col-end-6">
+        <div className="w-full h-full pt-20 md:pt-40 lg:pt-56">
           <Stack vertical spacing="loose">
-            <h1 className="text-4xl font-bold">{t("Oops We Couldnt Find What You Were Looking For")}</h1>
-            <h3 id="error404" className="text-primary text-3xl">
+            <h1 className="text-3xl md:text-4xl font-bold">{t("Oops We Couldnt Find What You Were Looking For")}</h1>
+            <h3 id="error404" className="text-primary text-2xl md:text-3xl">
               {t("Error: 404")}
             </h3>
             <p className="text-l">

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -54,7 +54,7 @@ function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   return (
     <AppProvider i18n={enTranslations}>
       <Head>
-        <meta name="viewport" content="initial-scale=1.0, width=device-width" />
+        <meta name="viewport" content="initial-scale=1.0, width=device-width, viewport-fit=cover" />
       </Head>
       <AuthProvider publicPage={publicPage}>
         <InBoxProvider>{getLayout(<Component {...pageProps} />)}</InBoxProvider>

--- a/pages/dpps/[id].tsx
+++ b/pages/dpps/[id].tsx
@@ -260,7 +260,7 @@ const DppDetailPage: NextPageWithLayout = () => {
 
   return (
     <div className="flex-1 bg-ifr-page" style={{ fontFamily: "var(--ifr-font-body)" }}>
-      <div className="max-w-[1180px] mx-auto px-6 py-8 flex flex-col gap-6">
+      <div className="max-w-[1180px] mx-auto px-4 md:px-6 py-6 md:py-8 flex flex-col gap-6">
         <Link href="/products">
           <a className="inline-flex items-center gap-2 no-underline text-ifr-text-secondary hover:text-ifr-text-primary">
             <ArrowLeft size={16} />
@@ -327,7 +327,7 @@ const DppDetailPage: NextPageWithLayout = () => {
             </nav>
 
             {/* Header card */}
-            <div className="bg-ifr-surface border border-ifr rounded-ifr-md p-6 flex flex-col gap-4">
+            <div className="bg-ifr-surface border border-ifr rounded-ifr-md p-4 md:p-6 flex flex-col gap-4">
               {/* Top row: label + actions */}
               <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-3">
                 <div className="flex flex-col gap-2">

--- a/pages/notification.tsx
+++ b/pages/notification.tsx
@@ -160,8 +160,10 @@ const Notification = () => {
   };
 
   return (
-    <div className="flex flex-wrap mx-auto justify-center">
-      <div className="flex flex-col p-6 space-y-1 sticky top-0 self-start z-40">
+    <div className="flex flex-col lg:flex-row flex-wrap mx-auto lg:justify-center">
+      {/* Group jump-links: a horizontal strip above the feed on phones, a
+          sticky rail beside it once there is room. */}
+      <div className="flex flex-row lg:flex-col gap-2 lg:gap-0 overflow-x-auto lg:overflow-visible p-4 md:p-6 lg:space-y-1 lg:sticky lg:top-0 self-start z-40">
         {nonEmptyGroups.map(([groupName, group]) => (
           <Button key={groupName} url={`#${groupName}`}>
             {/* @ts-ignore */}
@@ -171,7 +173,7 @@ const Notification = () => {
         ))}
       </div>
 
-      <div className="max-w-lg p-6 space-y-8">
+      <div className="w-full max-w-lg p-4 md:p-6 space-y-8">
         {unreadCount > 0 && (
           <div className="flex justify-end">
             <Button onClick={handleMarkAllRead}>{`${t("Mark all as read")} (${unreadCount})`}</Button>

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -39,8 +39,8 @@ export default function Projects() {
   const { t } = useTranslation("lastUpdatedProps");
   const { proposalFilter } = useFilters();
   return (
-    <div className="p-8">
-      <div className="mb-6 w-96">
+    <div className="p-4 md:p-8">
+      <div className="mb-6 w-full max-w-sm">
         <h1>{t("Latest projects")}</h1>
         <p className="my-2">{t("Most recently updated projects")}</p>
         <NewProjectButton text={t("Create a new project")} />

--- a/pages/proposal/[id].tsx
+++ b/pages/proposal/[id].tsx
@@ -172,7 +172,7 @@ const Proposal = () => {
 
   return (
     <>
-      <div className="mx-auto max-w-lg pt-6 min-h-full">
+      <div className="mx-auto w-full max-w-lg px-4 pt-6 min-h-full">
         <Stack vertical spacing="extraLoose">
           <div className="flex justify-between">
             <PTitleSubtitle title={t("Contribution Proposal")} subtitle={t("Read the comunity guidelines")} />
@@ -219,7 +219,7 @@ const Proposal = () => {
       </div>
 
       {renderActions && (
-        <div className="bg-yellow-100 border-t-1 border-t-border-warning-subdued p-4 flex justify-end items-center space-x-6 sticky bottom-0 z-20">
+        <div className="bg-yellow-100 border-t-1 border-t-border-warning-subdued p-4 flex flex-wrap justify-end items-center gap-3 sm:gap-6 sticky bottom-0 z-20">
           <div className="space-x-2">
             <Button
               size="large"

--- a/pages/resource/[id]/claim.tsx
+++ b/pages/resource/[id]/claim.tsx
@@ -171,11 +171,11 @@ const ClaimProject: NextPageWithLayout = () => {
   return (
     <FormProvider {...form}>
       <form onSubmit={handleSubmit(handleClaim)}>
-        <div className="flex justify-center items-start space-x-8 md:space-x-16 lg:space-x-24 p-6">
-          <div className="sticky top-24">
+        <div className="flex flex-col lg:flex-row lg:justify-center items-stretch lg:items-start gap-6 lg:gap-0 lg:space-x-16 xl:space-x-24 p-4 md:p-6">
+          <div className="lg:sticky lg:top-24 lg:shrink-0">
             <ClaimNav />
           </div>
-          <div className="grow max-w-xl px-6 pb-24 pt-0">
+          <div className="grow min-w-0 w-full max-w-xl mx-auto lg:mx-0 px-0 md:px-6 pb-24 pt-0">
             <Stack vertical spacing="extraLoose">
               <PTitleSubtitle
                 title={t("import this resource")}

--- a/pages/resource/[id]/index.tsx
+++ b/pages/resource/[id]/index.tsx
@@ -45,9 +45,9 @@ const Resource: NextPageWithLayout = () => {
   }, [project]);
 
   return (
-    <div className="p-4 container mx-auto flex max-w-6xl bg-[#f8f7f4] space-x-4">
+    <div className="p-4 container mx-auto flex max-w-6xl min-w-0 bg-[#f8f7f4] lg:space-x-4">
       <Stack spacing="extraLoose">
-        <div className="flex-grow max-w-screen-md">
+        <div className="flex-grow min-w-0 max-w-screen-md">
           <Stack vertical spacing="extraLoose">
             <ProjectHeader isResource />
             <BrThumbinailsGallery images={images} />

--- a/pages/resources.tsx
+++ b/pages/resources.tsx
@@ -26,8 +26,8 @@ const Resources: NextPageWithLayout = () => {
   devLog("Resources", resourceFilter);
   const { t } = useTranslation("resourcesProps");
   return (
-    <div className="p-8">
-      <div className="mb-6 w-80">
+    <div className="p-4 md:p-8">
+      <div className="mb-6 w-full max-w-xs">
         <h1>{t("Resources")}</h1>
         <p>{t("Use this page to generate digital product passports of resources")}</p>
       </div>

--- a/pages/scan.tsx
+++ b/pages/scan.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from "next-i18next";
 const Scan = () => {
   const { t } = useTranslation("common");
   return (
-    <div className="container mx-auto">
+    <div className="container mx-auto px-4 md:px-6">
       <Stack vertical>
         <PTitleSubtitle
           title={t("Scan your QR code")}

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -53,7 +53,7 @@ const Search: NextPageWithLayout = () => {
   //
 
   return (
-    <div className="container mx-auto">
+    <div className="container mx-auto px-4 md:px-6">
       <div className="p-8">
         <div className="mb-6">
           <h1>

--- a/pages/sign_in.tsx
+++ b/pages/sign_in.tsx
@@ -208,8 +208,8 @@ const Sign_in: NextPageWithLayout = () => {
 
   return (
     <div className="grid h-full grid-cols-6">
-      <div className="col-span-6 p-2 md:col-span-4 md:col-start-2 md:col-end-6">
-        <div className="w-full h-full pt-56">
+      <div className="col-span-6 px-4 py-2 md:col-span-4 md:col-start-2 md:col-end-6">
+        <div className="w-full h-full pt-12 md:pt-32 lg:pt-56">
           {/* Entering email */}
           {step === 0 && (
             <EnterEmail onSubmit={emailEntered}>{error && <BrError testID="error">{error}</BrError>}</EnterEmail>

--- a/pages/sign_up.tsx
+++ b/pages/sign_up.tsx
@@ -126,7 +126,7 @@ const SignUp: NextPageWithLayout = () => {
 
   return (
     <div className="grid h-full grid-cols-6 mt-2 md:mt-40">
-      <div className="col-span-6 p-2 md:col-span-4 md:col-start-2 md:col-end-6">
+      <div className="col-span-6 px-4 py-2 md:col-span-4 md:col-start-2 md:col-end-6">
         {/* Step 0: invitation key */}
         {step === 0 && <InvitationKey onSubmit={nextStep} />}
 

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -34,6 +34,43 @@ body {
   color: var(--ifr-text-primary);
 }
 
+/* No surface may push the page sideways. Wide content (tables, diagrams,
+   traceability graphs) scrolls inside its own container instead.
+   Scoped to `html` on purpose: adding it to `body` too would make body a
+   scroll container and break the sticky topbar and sidebars. */
+html {
+  overflow-x: hidden;
+}
+
+/* Respect notches and home indicators on the fixed page edges. */
+body {
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+}
+
+/* iOS zooms the page when a focused input is under 16px. Keep form controls
+   at 16px on touch devices; the visual scale is restored for fine pointers. */
+@media (pointer: coarse) {
+  input,
+  select,
+  textarea {
+    font-size: 16px;
+  }
+}
+
+/* Guarantee a thumb-sized hit area on touch input without inflating the
+   control for mouse users. Applied to icon-only buttons. */
+.tap-target {
+  @apply inline-flex items-center justify-center;
+}
+
+@media (pointer: coarse) {
+  .tap-target {
+    min-width: var(--ifr-tap-min);
+    min-height: var(--ifr-tap-min);
+  }
+}
+
 button,
 input,
 select,
@@ -85,6 +122,19 @@ p,
 }
 table {
   @apply table;
+}
+
+/* Wrapper for any data table too wide to fit a phone. The table keeps its
+   columns and scrolls horizontally inside this box; the page does not. */
+.table-scroll {
+  @apply w-full overflow-x-auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-x: contain;
+}
+
+.table-scroll > table {
+  min-width: 100%;
+  width: max-content;
 }
 
 .swiper-slide {

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -119,20 +119,34 @@
   --ifr-radius-lg: 8px;
   --ifr-radius-full: 9999px;
 
-  /* --- Layout sizes --- */
-  --ifr-topbar-height: 64px;
+  /* --- Layout sizes ---
+   * Mobile-first: these are the phone values. The `min-width` blocks below
+   * step them up for tablet and desktop. Anything sized from these tokens
+   * adapts without its own media query.
+   */
+  --ifr-topbar-height: 56px;
   --ifr-sidebar-width: 288px;
   --ifr-dropdown-width: 240px;
-  --ifr-avatar-size: 44px;
-  --ifr-avatar-profile-size: 88px;
-  --ifr-control-height: 36px;
-  --ifr-card-image-height: 240px;
+  --ifr-avatar-size: 36px;
+  --ifr-avatar-profile-size: 64px;
+  --ifr-control-height: 40px;
+  --ifr-card-image-height: 200px;
   --ifr-card-min-width: 300px;
   --ifr-card-max-width: 360px;
-  --ifr-grid-gap: 24px;
+  --ifr-grid-gap: 16px;
   --ifr-form-sidebar-width: 304px;
   --ifr-nav-menu-width: 280px;
   --ifr-nav-menu-divider: #e5a100;
+
+  /* Horizontal page gutter — shared by shells, heroes and toolbars */
+  --ifr-page-px: 16px;
+  /* Minimum comfortable touch target */
+  --ifr-tap-min: 44px;
+  /* Card grid track. `min(100%, …)` keeps a single card inside a 320px
+     viewport instead of forcing a horizontal scroll; the `1fr` maximum lets
+     the columns that do fit share the row evenly, rather than capping at
+     360px and stranding a wide gutter at tablet widths. */
+  --ifr-card-track: minmax(min(100%, var(--ifr-card-min-width)), 1fr);
 
   /* --- Form-specific --- */
   --ifr-bg-form-input: #fafbfb;
@@ -145,4 +159,32 @@
   /* --- Toggle switch --- */
   --ifr-switch-off: #cbd5e1;
   --ifr-switch-on: var(--ifr-green);
+}
+
+/* Tablet — Tailwind `md` */
+@media (min-width: 768px) {
+  :root {
+    --ifr-topbar-height: 64px;
+    --ifr-avatar-size: 44px;
+    --ifr-avatar-profile-size: 88px;
+    --ifr-card-image-height: 240px;
+    --ifr-grid-gap: 24px;
+    --ifr-page-px: 24px;
+  }
+}
+
+/* Desktop — Tailwind `lg` */
+@media (min-width: 1024px) {
+  :root {
+    --ifr-avatar-profile-size: 88px;
+  }
+}
+
+/* Pointer-based sizing: a mouse can hit a 36px control, a thumb cannot.
+   This keys off input method rather than screen width, so a touch laptop
+   gets the larger target too. */
+@media (pointer: fine) {
+  :root {
+    --ifr-control-height: 36px;
+  }
 }


### PR DESCRIPTION
## Summary
- make shared navigation, catalog filters, forms, profile, project, resource, search, and auth layouts responsive
- present catalog filters as an accessible mobile drawer and add mobile header search
- add fluid layout tokens, safe-area viewport support, and a shared media-query hook

## Validation
- `pnpm check-types`
- `pnpm check-lint` (passes with existing warnings)